### PR TITLE
allow custom module positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ _This release is scheduled to be released on 2024-01-01._
 
 ### Added
 
+- custom module positions
+  reason see e.g.
+
+  - https://github.com/MichMich/MagicMirror/issues/3212
+  - https://forum.magicmirror.builders/topic/18069/multiple-modules-in-a-region/17
+
+  usage:
+
+  - define own module positions as html in `config.js`, key is `modulePositions`
+  - define own css styles in a new file in the `css` directory, the name of this file is specified in `config.js`, key is `modulePositionsCss`
+
 ### Removed
 
 ### Updated

--- a/css/main.css
+++ b/css/main.css
@@ -146,11 +146,6 @@ sup {
   pointer-events: auto;
 }
 
-.region.bottom .module {
-  margin-top: var(--gap-modules);
-  margin-bottom: 0;
-}
-
 .no-wrap {
   white-space: nowrap;
   overflow: hidden;
@@ -159,83 +154,4 @@ sup {
 
 .pre-line {
   white-space: pre-line;
-}
-
-/**
- * Region Definitions.
- */
-
-.region {
-  position: absolute;
-}
-
-.region.fullscreen {
-  position: absolute;
-  inset: calc(-1 * var(--gap-body-top)) calc(-1 * var(--gap-body-right)) calc(-1 * var(--gap-body-bottom)) calc(-1 * var(--gap-body-left));
-  pointer-events: none;
-}
-
-.region.right {
-  right: 0;
-  text-align: right;
-}
-
-.region.top {
-  top: 0;
-}
-
-.region.top.center,
-.region.bottom.center {
-  left: 50%;
-  transform: translateX(-50%);
-}
-
-.region.top.right,
-.region.top.left,
-.region.top.center {
-  top: 100%;
-}
-
-.region.bottom {
-  bottom: 0;
-}
-
-.region.bottom.right,
-.region.bottom.center,
-.region.bottom.left {
-  bottom: 100%;
-}
-
-.region.bar {
-  width: 100%;
-  text-align: center;
-}
-
-.region.third,
-.region.middle.center {
-  width: 100%;
-  text-align: center;
-  transform: translateY(-50%);
-}
-
-.region.upper.third {
-  top: 33%;
-}
-
-.region.middle.center {
-  top: 50%;
-}
-
-.region.lower.third {
-  top: 66%;
-}
-
-.region.left {
-  text-align: left;
-}
-
-.region table {
-  width: 100%;
-  border-spacing: 0;
-  border-collapse: separate;
 }

--- a/css/module.css
+++ b/css/module.css
@@ -1,0 +1,83 @@
+/**
+ * Region Definitions.
+ */
+
+.region.bottom .module {
+  margin-top: var(--gap-modules);
+  margin-bottom: 0;
+}
+
+.region {
+  position: absolute;
+}
+
+.region.fullscreen {
+  position: absolute;
+  inset: calc(-1 * var(--gap-body-top)) calc(-1 * var(--gap-body-right)) calc(-1 * var(--gap-body-bottom)) calc(-1 * var(--gap-body-left));
+  pointer-events: none;
+}
+
+.region.right {
+  right: 0;
+  text-align: right;
+}
+
+.region.top {
+  top: 0;
+}
+
+.region.top.center,
+.region.bottom.center {
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.region.top.right,
+.region.top.left,
+.region.top.center {
+  top: 100%;
+}
+
+.region.bottom {
+  bottom: 0;
+}
+
+.region.bottom.right,
+.region.bottom.center,
+.region.bottom.left {
+  bottom: 100%;
+}
+
+.region.bar {
+  width: 100%;
+  text-align: center;
+}
+
+.region.third,
+.region.middle.center {
+  width: 100%;
+  text-align: center;
+  transform: translateY(-50%);
+}
+
+.region.upper.third {
+  top: 33%;
+}
+
+.region.middle.center {
+  top: 50%;
+}
+
+.region.lower.third {
+  top: 66%;
+}
+
+.region.left {
+  text-align: left;
+}
+
+.region table {
+  width: 100%;
+  border-spacing: 0;
+  border-collapse: separate;
+}

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
 
     <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
     <link rel="stylesheet" type="text/css" href="css/main.css" />
+    <link rel="stylesheet" type="text/css" href="css/#MODULE_CSS#" />
     <link rel="stylesheet" type="text/css" href="fonts/roboto.css" />
     <link rel="stylesheet" type="text/css" href="vendor/node_modules/animate.css/animate.min.css" />
     <!-- custom.css is loaded by the loader.js to make sure it's loaded after the module css files. -->
@@ -21,25 +22,7 @@
     </script>
   </head>
   <body>
-    <div class="region fullscreen below"><div class="container"></div></div>
-    <div class="region top bar">
-      <div class="container"></div>
-      <div class="region top left"><div class="container"></div></div>
-      <div class="region top center"><div class="container"></div></div>
-      <div class="region top right"><div class="container"></div></div>
-    </div>
-    <div class="region upper third"><div class="container"></div></div>
-    <div class="region middle center"><div class="container"></div></div>
-    <div class="region lower third">
-      <div class="container"><br /></div>
-    </div>
-    <div class="region bottom bar">
-      <div class="container"></div>
-      <div class="region bottom left"><div class="container"></div></div>
-      <div class="region bottom center"><div class="container"></div></div>
-      <div class="region bottom right"><div class="container"></div></div>
-    </div>
-    <div class="region fullscreen above"><div class="container"></div></div>
+    #MODULE_POSITIONS#
     <script type="text/javascript" src="socket.io/socket.io.js"></script>
     <script type="text/javascript" src="vendor/node_modules/nunjucks/browser/nunjucks.min.js"></script>
     <script type="text/javascript" src="js/defaults.js"></script>

--- a/js/defaults.js
+++ b/js/defaults.js
@@ -33,6 +33,9 @@ const defaults = {
 	// (interval 30 seconds). If startup-timestamp has changed the client reloads the magicmirror webpage.
 	checkServerInterval: 30 * 1000,
 	reloadAfterServerRestart: false,
+	modulePositions:
+		'<div class="region fullscreen below"><div class="container"></div></div><div class="region top bar"><div class="container"></div><div class="region top left"><div class="container"></div></div><div class="region top center"><div class="container"></div></div><div class="region top right"><div class="container"></div></div></div><div class="region upper third"><div class="container"></div></div><div class="region middle center"><div class="container"></div></div><div class="region lower third"><div class="container"><br /></div></div><div class="region bottom bar"><div class="container"></div><div class="region bottom left"><div class="container"></div></div><div class="region bottom center"><div class="container"></div></div><div class="region bottom right"><div class="container"></div></div></div><div class="region fullscreen above"><div class="container"></div></div>',
+	modulePositionsCss: "module.css",
 
 	modules: [
 		{

--- a/js/main.js
+++ b/js/main.js
@@ -457,7 +457,13 @@ const MM = (function () {
 	 * update notification is not visible.
 	 */
 	const updateWrapperStates = function () {
-		const positions = ["top_bar", "top_left", "top_center", "top_right", "upper_third", "middle_center", "lower_third", "bottom_left", "bottom_center", "bottom_right", "bottom_bar", "fullscreen_above", "fullscreen_below"];
+		let livePos = config.modulePositions.replaceAll('"', "").split("<div class=");
+		let positions = [];
+		for (let i in livePos) {
+			if (!livePos[i].includes("/div") && livePos[i].length > 0) {
+				positions.push(livePos[i].replace("region ", "").replace(">", "").replace(" ", "_"));
+			}
+		}
 
 		positions.forEach(function (position) {
 			const wrapper = selectWrapper(position);

--- a/js/server_functions.js
+++ b/js/server_functions.js
@@ -114,6 +114,8 @@ function getHtml(req, res) {
 		configFile = global.configuration_file;
 	}
 	html = html.replace("#CONFIG_FILE#", configFile);
+	html = html.replace("#MODULE_POSITIONS#", config.modulePositions);
+	html = html.replace("#MODULE_CSS#", config.modulePositionsCss);
 
 	res.send(html);
 }


### PR DESCRIPTION
I'm not sure if this should be merged but I tested this because of these discussions:
- https://github.com/MichMich/MagicMirror/issues/3212
- https://forum.magicmirror.builders/topic/18069/multiple-modules-in-a-region/17

With this PR you can
- define own module positions as html in `config.js`, key is `modulePositions`
- define own css styles in a new file in the `css` directory, the name of this file is specified in `config.js`, key is `modulePositionsCss`

So let me know whether we should offer this or not (no problem for me if not). This PR could be a basis for that.