### PR TITLE
Add systeminfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-❤️ **Donate:** Enjoying MagicMirror²? [Please consider a donation!](https://magicmirror.builders/donate) With your help we can continue to improve the MagicMirror².
+❤️ **Donate:** Enjoying MagicMirror²? [Please consider a donation!](https://magicmirror.builders/#donate) With your help we can continue to improve the MagicMirror².
 
 ## [2.27.0] - Develop Branch (unreleased)
 
 _This release is scheduled to be released on 2024-04-01._
 
 ### Added
+
+- Output of system information to the console for troubleshooting (#3328).
 
 ### Updated
 

--- a/js/app.js
+++ b/js/app.js
@@ -21,6 +21,9 @@ const defaultModules = require(`${__dirname}/../modules/default/defaultmodules`)
 global.version = require(`${__dirname}/../package.json`).version;
 Log.log(`Starting MagicMirror: v${global.version}`);
 
+// Log system information.
+Utils.logSystemInformation();
+
 // global absolute root path
 global.root_path = path.resolve(`${__dirname}/../`);
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -25,7 +25,7 @@ module.exports = {
 	async logSystemInformation  () {
 		try {
 			const staticData = await si.getStaticData();
-			let systemDataString = "The following lines provide information about your system and may be of interest when troubleshooting.";
+			let systemDataString = "System information:";
 			systemDataString += `\n ### SYSTEM:   manufacturer: ${staticData["system"]["manufacturer"]}; model: ${staticData["system"]["model"]}; raspberry: ${staticData["system"]["raspberry"]}; virtual: ${staticData["system"]["virtual"]}`;
 			systemDataString += `\n ### OS:       platform: ${staticData["os"]["platform"]}; distro: ${staticData["os"]["distro"]}; release: ${staticData["os"]["release"]}`;
 			systemDataString += `\n ### VERSIONS: MagicMirror: ${global.version}; electron: ${global.electronVersion}; kernel: ${staticData["versions"]["kernel"]}; node: ${staticData["versions"]["node"]}; npm: ${staticData["versions"]["npm"]}; pm2: ${staticData["versions"]["pm2"]}; docker: ${staticData["versions"]["docker"]}`;

--- a/js/utils.js
+++ b/js/utils.js
@@ -11,7 +11,7 @@ const si = require("systeminformation");
 try {
 	global.electronVersion = require(`${__dirname}/../node_modules/electron/package.json`).version;
 } catch (error) {
-	Log.error(`Can't find electron. Have you performed 'npm run install-mm'? ${error}`);
+	global.electronVersion = "not installed";
 }
 
 module.exports = {

--- a/js/utils.js
+++ b/js/utils.js
@@ -23,7 +23,6 @@ module.exports = {
 			systemDataString += `\n ### SYSTEM:   manufacturer: ${staticData["system"]["manufacturer"]}; model: ${staticData["system"]["model"]}; raspberry: ${staticData["system"]["raspberry"]}; virtual: ${staticData["system"]["virtual"]}`;
 			systemDataString += `\n ### OS:       platform: ${staticData["os"]["platform"]}; distro: ${staticData["os"]["distro"]}; release: ${staticData["os"]["release"]}; arch: ${staticData["os"]["arch"]}; kernel: ${staticData["versions"]["kernel"]}`;
 			systemDataString += `\n ### VERSIONS: electron: ${process.versions.electron}; node: ${staticData["versions"]["node"]}; npm: ${staticData["versions"]["npm"]}; pm2: ${staticData["versions"]["pm2"]}; docker: ${staticData["versions"]["docker"]}`;
-			if (typeof staticData["dockerInfo"] !== "undefined") systemDataString += `\n ### DOCKER:   containers: ${staticData["dockerInfo"]["containers"]}; operatingSystem: ${staticData["dockerInfo"]["operatingSystem"]}; osType: ${staticData["versions"]["osType"]}; architecture: ${staticData["versions"]["architecture"]}; serverVersion: ${staticData["versions"]["serverVersion"]}`;
 			systemDataString += `\n ### OTHER:    timeZone: ${Intl.DateTimeFormat().resolvedOptions().timeZone}`;
 			Log.info(systemDataString);
 		} catch (e) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -24,6 +24,7 @@ module.exports = {
 			systemDataString += `\n ### OS:       platform: ${staticData["os"]["platform"]}; distro: ${staticData["os"]["distro"]}; release: ${staticData["os"]["release"]}; kernel: ${staticData["versions"]["kernel"]}`;
 			systemDataString += `\n ### VERSIONS: electron: ${process.versions.electron}; node: ${staticData["versions"]["node"]}; npm: ${staticData["versions"]["npm"]}; pm2: ${staticData["versions"]["pm2"]}; docker: ${staticData["versions"]["docker"]}`;
 			if (typeof staticData["dockerInfo"] !== "undefined") systemDataString += `\n ### DOCKER:   containers: ${staticData["dockerInfo"]["containers"]}; operatingSystem: ${staticData["dockerInfo"]["operatingSystem"]}; osType: ${staticData["versions"]["osType"]}; architecture: ${staticData["versions"]["architecture"]}; serverVersion: ${staticData["versions"]["serverVersion"]}`;
+			systemDataString += `\n ### OTHER:    timeZone: ${Intl.DateTimeFormat().resolvedOptions().timeZone}`;
 			Log.info(systemDataString);
 		} catch (e) {
 			Log.error(e);

--- a/js/utils.js
+++ b/js/utils.js
@@ -8,12 +8,6 @@ const colors = require("colors/safe");
 const Log = require("logger");
 const si = require("systeminformation");
 
-try {
-	global.electronVersion = require(`${__dirname}/../node_modules/electron/package.json`).version;
-} catch (error) {
-	global.electronVersion = "not installed";
-}
-
 module.exports = {
 	colors: {
 		warn: colors.yellow,
@@ -28,7 +22,7 @@ module.exports = {
 			let systemDataString = "System information:";
 			systemDataString += `\n ### SYSTEM:   manufacturer: ${staticData["system"]["manufacturer"]}; model: ${staticData["system"]["model"]}; raspberry: ${staticData["system"]["raspberry"]}; virtual: ${staticData["system"]["virtual"]}`;
 			systemDataString += `\n ### OS:       platform: ${staticData["os"]["platform"]}; distro: ${staticData["os"]["distro"]}; release: ${staticData["os"]["release"]}`;
-			systemDataString += `\n ### VERSIONS: MagicMirror: ${global.version}; electron: ${global.electronVersion}; kernel: ${staticData["versions"]["kernel"]}; node: ${staticData["versions"]["node"]}; npm: ${staticData["versions"]["npm"]}; pm2: ${staticData["versions"]["pm2"]}; docker: ${staticData["versions"]["docker"]}`;
+			systemDataString += `\n ### VERSIONS: MagicMirror: ${global.version}; electron: ${process.versions.electron}; kernel: ${staticData["versions"]["kernel"]}; node: ${staticData["versions"]["node"]}; npm: ${staticData["versions"]["npm"]}; pm2: ${staticData["versions"]["pm2"]}; docker: ${staticData["versions"]["docker"]}`;
 			if (typeof staticData["dockerInfo"] !== "undefined") systemDataString += `\n ### DOCKER:   containers: ${staticData["dockerInfo"]["containers"]}; operatingSystem: ${staticData["dockerInfo"]["operatingSystem"]}; osType: ${staticData["versions"]["osType"]}; architecture: ${staticData["versions"]["architecture"]}; serverVersion: ${staticData["versions"]["serverVersion"]}`;
 			Log.info(systemDataString);
 		} catch (e) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -22,7 +22,7 @@ module.exports = {
 			let systemDataString = "System information:";
 			systemDataString += `\n ### SYSTEM:   manufacturer: ${staticData["system"]["manufacturer"]}; model: ${staticData["system"]["model"]}; raspberry: ${staticData["system"]["raspberry"]}; virtual: ${staticData["system"]["virtual"]}`;
 			systemDataString += `\n ### OS:       platform: ${staticData["os"]["platform"]}; distro: ${staticData["os"]["distro"]}; release: ${staticData["os"]["release"]}`;
-			systemDataString += `\n ### VERSIONS: MagicMirror: ${global.version}; electron: ${process.versions.electron}; kernel: ${staticData["versions"]["kernel"]}; node: ${staticData["versions"]["node"]}; npm: ${staticData["versions"]["npm"]}; pm2: ${staticData["versions"]["pm2"]}; docker: ${staticData["versions"]["docker"]}`;
+			systemDataString += `\n ### VERSIONS: electron: ${process.versions.electron}; kernel: ${staticData["versions"]["kernel"]}; node: ${staticData["versions"]["node"]}; npm: ${staticData["versions"]["npm"]}; pm2: ${staticData["versions"]["pm2"]}; docker: ${staticData["versions"]["docker"]}`;
 			if (typeof staticData["dockerInfo"] !== "undefined") systemDataString += `\n ### DOCKER:   containers: ${staticData["dockerInfo"]["containers"]}; operatingSystem: ${staticData["dockerInfo"]["operatingSystem"]}; osType: ${staticData["versions"]["osType"]}; architecture: ${staticData["versions"]["architecture"]}; serverVersion: ${staticData["versions"]["serverVersion"]}`;
 			Log.info(systemDataString);
 		} catch (e) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -21,8 +21,8 @@ module.exports = {
 			const staticData = await si.getStaticData();
 			let systemDataString = "System information:";
 			systemDataString += `\n ### SYSTEM:   manufacturer: ${staticData["system"]["manufacturer"]}; model: ${staticData["system"]["model"]}; raspberry: ${staticData["system"]["raspberry"]}; virtual: ${staticData["system"]["virtual"]}`;
-			systemDataString += `\n ### OS:       platform: ${staticData["os"]["platform"]}; distro: ${staticData["os"]["distro"]}; release: ${staticData["os"]["release"]}`;
-			systemDataString += `\n ### VERSIONS: electron: ${process.versions.electron}; kernel: ${staticData["versions"]["kernel"]}; node: ${staticData["versions"]["node"]}; npm: ${staticData["versions"]["npm"]}; pm2: ${staticData["versions"]["pm2"]}; docker: ${staticData["versions"]["docker"]}`;
+			systemDataString += `\n ### OS:       platform: ${staticData["os"]["platform"]}; distro: ${staticData["os"]["distro"]}; release: ${staticData["os"]["release"]}; kernel: ${staticData["versions"]["kernel"]}`;
+			systemDataString += `\n ### VERSIONS: electron: ${process.versions.electron}; node: ${staticData["versions"]["node"]}; npm: ${staticData["versions"]["npm"]}; pm2: ${staticData["versions"]["pm2"]}; docker: ${staticData["versions"]["docker"]}`;
 			if (typeof staticData["dockerInfo"] !== "undefined") systemDataString += `\n ### DOCKER:   containers: ${staticData["dockerInfo"]["containers"]}; operatingSystem: ${staticData["dockerInfo"]["operatingSystem"]}; osType: ${staticData["versions"]["osType"]}; architecture: ${staticData["versions"]["architecture"]}; serverVersion: ${staticData["versions"]["serverVersion"]}`;
 			Log.info(systemDataString);
 		} catch (e) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -21,7 +21,7 @@ module.exports = {
 			const staticData = await si.getStaticData();
 			let systemDataString = "System information:";
 			systemDataString += `\n ### SYSTEM:   manufacturer: ${staticData["system"]["manufacturer"]}; model: ${staticData["system"]["model"]}; raspberry: ${staticData["system"]["raspberry"]}; virtual: ${staticData["system"]["virtual"]}`;
-			systemDataString += `\n ### OS:       platform: ${staticData["os"]["platform"]}; distro: ${staticData["os"]["distro"]}; release: ${staticData["os"]["release"]}; kernel: ${staticData["versions"]["kernel"]}`;
+			systemDataString += `\n ### OS:       platform: ${staticData["os"]["platform"]}; distro: ${staticData["os"]["distro"]}; release: ${staticData["os"]["release"]}; arch: ${staticData["os"]["arch"]}; kernel: ${staticData["versions"]["kernel"]}`;
 			systemDataString += `\n ### VERSIONS: electron: ${process.versions.electron}; node: ${staticData["versions"]["node"]}; npm: ${staticData["versions"]["npm"]}; pm2: ${staticData["versions"]["pm2"]}; docker: ${staticData["versions"]["docker"]}`;
 			if (typeof staticData["dockerInfo"] !== "undefined") systemDataString += `\n ### DOCKER:   containers: ${staticData["dockerInfo"]["containers"]}; operatingSystem: ${staticData["dockerInfo"]["operatingSystem"]}; osType: ${staticData["versions"]["osType"]}; architecture: ${staticData["versions"]["architecture"]}; serverVersion: ${staticData["versions"]["serverVersion"]}`;
 			systemDataString += `\n ### OTHER:    timeZone: ${Intl.DateTimeFormat().resolvedOptions().timeZone}`;

--- a/js/utils.js
+++ b/js/utils.js
@@ -5,6 +5,14 @@
  * MIT Licensed.
  */
 const colors = require("colors/safe");
+const Log = require("logger");
+const si = require("systeminformation");
+
+try {
+	global.electronVersion = require(`${__dirname}/../node_modules/electron/package.json`).version;
+} catch (error) {
+	Log.error(`Can't find electron. Have you performed 'npm run install-mm'? ${error}`);
+}
 
 module.exports = {
 	colors: {
@@ -12,5 +20,19 @@ module.exports = {
 		error: colors.red,
 		info: colors.blue,
 		pass: colors.green
+	},
+
+	async logSystemInformation  () {
+		try {
+			const staticData = await si.getStaticData();
+			let systemDataString = "The following lines provide information about your system and may be of interest when troubleshooting.";
+			systemDataString += `\n ### SYSTEM:   manufacturer: ${staticData["system"]["manufacturer"]}; model: ${staticData["system"]["model"]}; raspberry: ${staticData["system"]["raspberry"]}; virtual: ${staticData["system"]["virtual"]}`;
+			systemDataString += `\n ### OS:       platform: ${staticData["os"]["platform"]}; distro: ${staticData["os"]["distro"]}; release: ${staticData["os"]["release"]}`;
+			systemDataString += `\n ### VERSIONS: MagicMirror: ${global.version}; electron: ${global.electronVersion}; kernel: ${staticData["versions"]["kernel"]}; node: ${staticData["versions"]["node"]}; npm: ${staticData["versions"]["npm"]}; pm2: ${staticData["versions"]["pm2"]}; docker: ${staticData["versions"]["docker"]}`;
+			if (typeof staticData["dockerInfo"] !== "undefined") systemDataString += `\n ### DOCKER:   containers: ${staticData["dockerInfo"]["containers"]}; operatingSystem: ${staticData["dockerInfo"]["operatingSystem"]}; osType: ${staticData["versions"]["osType"]}; architecture: ${staticData["versions"]["architecture"]}; serverVersion: ${staticData["versions"]["serverVersion"]}`;
+			Log.info(systemDataString);
+		} catch (e) {
+			Log.error(e);
+		}
 	}
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
 				"module-alias": "^2.2.3",
 				"moment": "^2.30.1",
 				"node-ical": "^0.17.1",
-				"socket.io": "^4.7.2"
+				"socket.io": "^4.7.2",
+				"systeminformation": "^5.21.22"
 			},
 			"devDependencies": {
 				"@stylistic/eslint-plugin": "^1.5.1",
@@ -9296,6 +9297,31 @@
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true
+		},
+		"node_modules/systeminformation": {
+			"version": "5.21.22",
+			"resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.21.22.tgz",
+			"integrity": "sha512-gNHloAJSyS+sKWkwvmvozZ1eHrdVTEsynWMTY6lvLGBB70gflkBQFw8drXXr1oEXY84+Vr9tOOrN8xHZLJSycA==",
+			"os": [
+				"darwin",
+				"linux",
+				"win32",
+				"freebsd",
+				"openbsd",
+				"netbsd",
+				"sunos",
+				"android"
+			],
+			"bin": {
+				"systeminformation": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"funding": {
+				"type": "Buy me a coffee",
+				"url": "https://www.buymeacoffee.com/systeminfo"
+			}
 		},
 		"node_modules/table": {
 			"version": "6.8.1",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
 		"module-alias": "^2.2.3",
 		"moment": "^2.30.1",
 		"node-ical": "^0.17.1",
-		"socket.io": "^4.7.2"
+		"socket.io": "^4.7.2",
+		"systeminformation": "^5.21.22"
 	},
 	"lint-staged": {
 		"*": "prettier --write",


### PR DESCRIPTION
This is a first attempt to bring additional system information into the console (see #3328). It's certainly not yet perfect, but with the PR we have a better basis for discussion.

I tried to keep the output small so that we get as much information as possible in screenshots.

This is how it looks on my development system.

```bash
[03.01.2024 00:50.19.226] [INFO] System information:
 ### SYSTEM:   manufacturer: Notebook; model: N650DU; raspberry: undefined; virtual: false
 ### OS:       platform: linux; distro: Debian GNU/Linux; release: 12
 ### VERSIONS: MagicMirror: 2.27.0-develop; electron: 27.2.0; kernel: 5.10.0-20-amd64; node: 21.1.0; npm: 10.2.4; pm2: 5.3.0; docker: 20.10.24+dfsg1
 ```
 
 Why is it still a draft:
- [x] I have doubts that utils.js is the right place for the function. What do you think?
=> Update: As long as there is no better idea, it stays there.
- [x] Instead of working through all wishes you expressed in the issue #3328, I only implemented what was easy to achieve. And wanted to hear what you think about this approach.
=> Update: Some added. Of course, more information could be added later, as soon as experience has been gained in productive use.
- [x] I don't quite like the introductory line ("The following lines provide information..."). Should I perhaps simply replace it with "System information:"?
=> Update: Changed to "System information:"
 
 [Here](https://github.com/sebhildebrandt/systeminformation#function-reference-and-os-support) you can see what information we could easily add with the systeminformation package.
 
 It would be interesting how the raspberry field is filled on a raspi system and with docker there should be another line, but I can't easily test that now.