### PR TITLE
Update system information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ _This release is scheduled to be released on 2024-04-01._
 
 ### Added
 
-- Output of system information to the console for troubleshooting (#3328)
+- Output of system information to the console for troubleshooting (#3328 and #3337)
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ _This release is scheduled to be released on 2024-04-01._
 
 ### Added
 
-- Output of system information to the console for troubleshooting (#3328).
+- Output of system information to the console for troubleshooting (#3328)
 
 ### Updated
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -4,6 +4,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
+const execSync = require("child_process").execSync;
 const colors = require("colors/safe");
 const Log = require("logger");
 const si = require("systeminformation");
@@ -18,12 +19,13 @@ module.exports = {
 
 	async logSystemInformation  () {
 		try {
+			let installedNodeVersion = execSync("node -v", { encoding: "utf-8" }).replace("v", "").replace(/(?:\r\n|\r|\n)/g, "");
 			const staticData = await si.getStaticData();
 			let systemDataString = "System information:";
-			systemDataString += `\n ### SYSTEM:   manufacturer: ${staticData["system"]["manufacturer"]}; model: ${staticData["system"]["model"]}; raspberry: ${staticData["system"]["raspberry"]}; virtual: ${staticData["system"]["virtual"]}`;
-			systemDataString += `\n ### OS:       platform: ${staticData["os"]["platform"]}; distro: ${staticData["os"]["distro"]}; release: ${staticData["os"]["release"]}; arch: ${staticData["os"]["arch"]}; kernel: ${staticData["versions"]["kernel"]}`;
-			systemDataString += `\n ### VERSIONS: electron: ${process.versions.electron}; node: ${staticData["versions"]["node"]}; npm: ${staticData["versions"]["npm"]}; pm2: ${staticData["versions"]["pm2"]}; docker: ${staticData["versions"]["docker"]}`;
-			systemDataString += `\n ### OTHER:    timeZone: ${Intl.DateTimeFormat().resolvedOptions().timeZone}`;
+			systemDataString += `\n### SYSTEM:   manufacturer: ${staticData["system"]["manufacturer"]}; model: ${staticData["system"]["model"]}; raspberry: ${staticData["system"]["raspberry"]}; virtual: ${staticData["system"]["virtual"]}`;
+			systemDataString += `\n### OS:       platform: ${staticData["os"]["platform"]}; distro: ${staticData["os"]["distro"]}; release: ${staticData["os"]["release"]}; arch: ${staticData["os"]["arch"]}; kernel: ${staticData["versions"]["kernel"]}`;
+			systemDataString += `\n### VERSIONS: electron: ${process.versions.electron}; used node: ${staticData["versions"]["node"]}; installed node: ${installedNodeVersion}; npm: ${staticData["versions"]["npm"]}; pm2: ${staticData["versions"]["pm2"]}`;
+			systemDataString += `\n### OTHER:    timeZone: ${Intl.DateTimeFormat().resolvedOptions().timeZone}; ELECTRON_ENABLE_GPU: ${process.env.ELECTRON_ENABLE_GPU}`;
 			Log.info(systemDataString);
 		} catch (e) {
 			Log.error(e);

--- a/serveronly/index.js
+++ b/serveronly/index.js
@@ -4,5 +4,5 @@ const Log = require("../js/logger");
 app.start().then((config) => {
 	const bindAddress = config.address ? config.address : "localhost";
 	const httpType = config.useHttps ? "https" : "http";
-	Log.log(`\nReady to go! Please point your browser to: ${httpType}://${bindAddress}:${config.port}`);
+	Log.info(`\n>>>   Ready to go! Please point your browser to: ${httpType}://${bindAddress}:${config.port}   <<<`);
 });


### PR DESCRIPTION
- Add ELECTRON_ENABLE_GPU
- Remove docker version
- Differentiation between installed and used node version
- Highlight "Ready to go!" for server mode (Since we display system information in the console, it is easy to overlook this important line.)

## Electron mode

### Before

```bash
[07.01.2024 16:37.30.591] [INFO]  System information:
 ### SYSTEM:   manufacturer: Notebook; model: N650DU; raspberry: undefined; virtual: false
 ### OS:       platform: linux; distro: Debian GNU/Linux; release: 12; arch: x64; kernel: 5.10.0-20-amd64
 ### VERSIONS: electron: 27.2.0; node: 18.17.1; npm: 10.2.4; pm2: 5.3.0; docker: 20.10.24+dfsg1
 ### OTHER:    timeZone: Europe/Berlin
```

### After

```bash
[07.01.2024 16:39.04.736] [INFO]  System information:
### SYSTEM:   manufacturer: Notebook; model: N650DU; raspberry: undefined; virtual: false
### OS:       platform: linux; distro: Debian GNU/Linux; release: 12; arch: x64; kernel: 5.10.0-20-amd64
### VERSIONS: electron: 27.2.0; used node: 18.17.1; installed node: 21.1.0; npm: 10.2.4; pm2: 5.3.0
### OTHER:    timeZone: Europe/Berlin; ELECTRON_ENABLE_GPU: undefined
```

## server mode

### Before

```bash
[07.01.2024 16:36.49.106] [LOG]   
Ready to go! Please point your browser to: http://localhost:8080
[07.01.2024 16:36.49.287] [INFO]  System information:
 ### SYSTEM:   manufacturer: Notebook; model: N650DU; raspberry: undefined; virtual: false
 ### OS:       platform: linux; distro: Debian GNU/Linux; release: 12; arch: x64; kernel: 5.10.0-20-amd64
 ### VERSIONS: electron: undefined; node: 21.1.0; npm: 10.2.4; pm2: 5.3.0; docker: 20.10.24+dfsg1
 ### OTHER:    timeZone: Europe/Berlin
```

### After

```bash
[2024-01-07 16:33:53.804] [INFO]  
>>>   Ready to go! Please point your browser to: http://localhost:8080   <<< 
[2024-01-07 16:33:53.997] [INFO]  System information:
### SYSTEM:   manufacturer: Notebook; model: N650DU; raspberry: undefined; virtual: false
### OS:       platform: linux; distro: Debian GNU/Linux; release: 12; arch: x64; kernel: 5.10.0-20-amd64
### VERSIONS: electron: undefined; used node: 21.1.0; installed node: 21.1.0; npm: 10.2.4; pm2: 5.3.0
### OTHER:    timeZone: Europe/Berlin; ELECTRON_ENABLE_GPU: undefined 
```