### PR TITLE
Ignore all custom css files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,8 +63,10 @@ Temporary Items
 !/modules/default/**
 !/modules/README.md**
 
-# Ignore changes to the custom css files.
-/css/custom.css
+# Ignore changes to the custom css files but keep the sample and main.
+/css/*
+!/css/custom.css.sample
+!/css/main.css
 
 # Ignore users config file but keep the sample.
 /config/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,14 @@ _This release is scheduled to be released on 2024-04-01._
 - Removing lodash dependency by replacing merge by spread operator (#3339)
 - Use node prefix for build-in modules (#3340)
 - Rework logging colors (#3350)
-- Update electron to v28 and update other dependencies
+- Update electron to v28 and update other dependencies (#3357)
 
 ### Fixed
 
 - Skip changelog requirement when running tests for dependency updates (#3320)
-- [newsfeed] Suppress unsightly animation cases when there are 0 or 1 active news items
-- [newsfeed] Always compute the feed item URL using the same helper function
+- [newsfeed] Suppress unsightly animation cases when there are 0 or 1 active news items (#3336)
+- [newsfeed] Always compute the feed item URL using the same helper function (#3336)
+- Ignore all custom css files (#3359)
 
 ### Deleted
 


### PR DESCRIPTION
For experimenting, I sometimes work with different CSS files. I can imagine that others do this too.

This setting for the css folder corresponds to the setting we already have for the config folder.