### PR TITLE
[newsfeed] Fix bug where the newsfeed sometimes stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ _This release is scheduled to be released on 2024-04-01._
 - [newsfeed] Suppress unsightly animation cases when there are 0 or 1 active news items (#3336)
 - [newsfeed] Always compute the feed item URL using the same helper function (#3336)
 - Ignore all custom css files (#3359)
+- [newsfeed] Fix newsfeed stall issue introduced by #3336 (#3361)
 
 ### Deleted
 

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -335,7 +335,7 @@ Module.register("newsfeed", {
 			 *
 			 * (N.B. We set activeItemCount and activeItemHash in getTemplateData().)
 			 */
-			if (this.newsItems.length !== this.activeItemCount || this.activeItemHash !== this.newsItems[0]?.hash) {
+			if (this.newsItems.length > 1 || this.newsItems.length !== this.activeItemCount || this.activeItemHash !== this.newsItems[0]?.hash) {
 				this.activeItem++; // this is OK if newsItems.Length==1; getTemplateData will wrap it around
 				this.updateDom(this.config.animationSpeed);
 			}


### PR DESCRIPTION
It appears that #3336 introduced a bug where a newsfeed with >1 items would stop updating after a while (usually after `activeItem` wraps around the end of the list). Sorry! My bad, I hadn't tested that case well enough.