### PR TITLE
remove all useless header comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ _This release is scheduled to be released on 2024-04-01._
 
 ### Deleted
 
+- Unneeded file headers (#3358)
+
 ## [2.26.0] - 01-01-2024
 
 Thanks to: @bnitkin, @bugsounet, @dependabot, @jkriegshauser, @kaennchenstruggle, @KristjanESPERANTO and @Ybbet.

--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -1,3 +1,13 @@
+/* Config Sample
+ *
+ * For more information on how you can configure this file
+ * see https://docs.magicmirror.builders/configuration/introduction.html
+ * and https://docs.magicmirror.builders/modules/configuration.html
+ *
+ * You can use environment variables using a `config.js.template` file instead of `config.js`
+ * which will be converted to `config.js` while starting. For more information
+ * see https://docs.magicmirror.builders/configuration/introduction.html#enviromnent-variables
+ */
 let config = {
 	address: "localhost",	// Address to listen on, can be:
 							// - "localhost", "127.0.0.1", "::1" to listen on loopback interface

--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -1,16 +1,3 @@
-/* MagicMirror² Config Sample
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- *
- * For more information on how you can configure this file
- * see https://docs.magicmirror.builders/configuration/introduction.html
- * and https://docs.magicmirror.builders/modules/configuration.html
- *
- * You can use environment variables using a `config.js.template` file instead of `config.js`
- * which will be converted to `config.js` while starting. For more information
- * see https://docs.magicmirror.builders/configuration/introduction.html#enviromnent-variables
- */
 let config = {
 	address: "localhost",	// Address to listen on, can be:
 							// - "localhost", "127.0.0.1", "::1" to listen on loopback interface

--- a/css/custom.css.sample
+++ b/css/custom.css.sample
@@ -1,3 +1,10 @@
+/* Custom CSS Sample
+ *
+ * Change color and fonts here.
+ *
+ * Beware that properties cannot be unitless, so for example write '--gap-body: 0px;' instead of just '--gap-body: 0;'
+ */
+
 /* Uncomment and adjust accordingly if you want to import another font from the google-fonts-api: */
 /* @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@100;300;400;700&display=swap'); */
 
@@ -9,7 +16,7 @@
 
   --font-primary: "Roboto Condensed";
   --font-secondary: "Roboto";
-  
+
   --font-size: 20px;
   --font-size-small: 0.75rem;
 
@@ -17,6 +24,6 @@
   --gap-body-right: 60px;
   --gap-body-bottom: 60px;
   --gap-body-left: 60px;
-  
+
   --gap-modules: 30px;
 }

--- a/css/custom.css.sample
+++ b/css/custom.css.sample
@@ -1,12 +1,3 @@
-/* MagicMirror² Custom CSS Sample
- *
- * Change color and fonts here.
- *
- * Beware that properties cannot be unitless, so for example write '--gap-body: 0px;' instead of just '--gap-body: 0;'
- *
- * MIT Licensed.
- */
-
 /* Uncomment and adjust accordingly if you want to import another font from the google-fonts-api: */
 /* @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@100;300;400;700&display=swap'); */
 

--- a/js/animateCSS.js
+++ b/js/animateCSS.js
@@ -1,10 +1,3 @@
-/* MagicMirror²
- * AnimateCSS System from https://animate.style/
- * by @bugsounet
- * for Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
-
 /* enumeration of animations in Array **/
 const AnimateCSSIn = [
 	// Attention seekers

--- a/js/app.js
+++ b/js/app.js
@@ -1,10 +1,3 @@
-/* MagicMirror²
- * The Core App (Server)
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
-
 // Alias modules mentioned in package.js under _moduleAliases.
 require("module-alias/register");
 

--- a/js/check_config.js
+++ b/js/check_config.js
@@ -1,10 +1,3 @@
-/* MagicMirror²
- *
- * Check the configuration file for errors
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 const path = require("node:path");
 const fs = require("node:fs");
 const colors = require("ansis");

--- a/js/class.js
+++ b/js/class.js
@@ -1,12 +1,5 @@
 /* global Class, xyz */
 
-/* Simple JavaScript Inheritance
- * By John Resig https://johnresig.com/
- *
- * Inspired by base2 and Prototype
- *
- * MIT Licensed.
- */
 (function () {
 	let initializing = false;
 	const fnTest = (/xyz/).test(function () {

--- a/js/class.js
+++ b/js/class.js
@@ -1,5 +1,12 @@
 /* global Class, xyz */
 
+/* Simple JavaScript Inheritance
+ * By John Resig https://johnresig.com/
+ *
+ * Inspired by base2 and Prototype
+ *
+ * MIT Licensed.
+ */
 (function () {
 	let initializing = false;
 	const fnTest = (/xyz/).test(function () {

--- a/js/defaults.js
+++ b/js/defaults.js
@@ -1,11 +1,5 @@
 /* global mmPort */
 
-/* MagicMirror²
- * Config Defaults
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
 const address = "localhost";
 let port = 8080;
 if (typeof mmPort !== "undefined") {

--- a/js/deprecated.js
+++ b/js/deprecated.js
@@ -1,11 +1,3 @@
-/* MagicMirror² Deprecated Config Options List
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- *
- * Olex S. original idea this deprecated option
- */
-
 module.exports = {
 	configs: ["kioskmode"]
 };

--- a/js/loader.js
+++ b/js/loader.js
@@ -1,11 +1,5 @@
 /* global defaultModules, vendor */
 
-/* MagicMirror²
- * Module and File loaders.
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
 const Loader = (function () {
 
 	/* Create helper variables */

--- a/js/logger.js
+++ b/js/logger.js
@@ -1,12 +1,3 @@
-/* MagicMirror²
- * Log
- *
- * This logger is very simple, but needs to be extended.
- * This system can eventually be used to push the log messages to an external target.
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
 (function (root, factory) {
 	if (typeof exports === "object") {
 		if (process.env.JEST_WORKER_ID === undefined) {

--- a/js/logger.js
+++ b/js/logger.js
@@ -1,3 +1,4 @@
+// This logger is very simple, but needs to be extended.
 (function (root, factory) {
 	if (typeof exports === "object") {
 		if (process.env.JEST_WORKER_ID === undefined) {

--- a/js/main.js
+++ b/js/main.js
@@ -1,11 +1,5 @@
 /* global Loader, defaults, Translator, addAnimateCSS, removeAnimateCSS, AnimateCSSIn, AnimateCSSOut */
 
-/* MagicMirror²
- * Main System
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
 const MM = (function () {
 	let modules = [];
 

--- a/js/module.js
+++ b/js/module.js
@@ -1,12 +1,5 @@
 /* global Class, cloneObject, Loader, MMSocket, nunjucks, Translator */
 
-/* MagicMirror²
- * Module Blueprint.
- * @typedef {Object} Module
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
 const Module = Class.extend({
 
 	/*********************************************************

--- a/js/module.js
+++ b/js/module.js
@@ -1,5 +1,8 @@
 /* global Class, cloneObject, Loader, MMSocket, nunjucks, Translator */
 
+/* Module Blueprint.
+ * @typedef {Object} Module
+ */
 const Module = Class.extend({
 
 	/*********************************************************

--- a/js/node_helper.js
+++ b/js/node_helper.js
@@ -1,9 +1,3 @@
-/* MagicMirror²
- * Node Helper Superclass
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
 const express = require("express");
 const Log = require("logger");
 const Class = require("./class");

--- a/js/server.js
+++ b/js/server.js
@@ -1,9 +1,3 @@
-/* MagicMirror²
- * Server
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
 const fs = require("node:fs");
 const http = require("node:http");
 const https = require("node:https");

--- a/js/socketclient.js
+++ b/js/socketclient.js
@@ -1,11 +1,5 @@
 /* global io */
 
-/* MagicMirror²
- * TODO add description
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
 const MMSocket = function (moduleName) {
 	if (typeof moduleName !== "string") {
 		throw new Error("Please set the module name for the MMSocket.");

--- a/js/translator.js
+++ b/js/translator.js
@@ -1,11 +1,5 @@
 /* global translations */
 
-/* MagicMirror²
- * Translator (l10n)
- *
- * By Christopher Fenner https://github.com/CFenner
- * MIT Licensed.
- */
 const Translator = (function () {
 
 	/**

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,8 +1,3 @@
-/* MagicMirror²
- * Utils
- *
- * MIT Licensed.
- */
 const execSync = require("node:child_process").execSync;
 const Log = require("logger");
 const si = require("systeminformation");

--- a/modules/default/alert/alert.js
+++ b/modules/default/alert/alert.js
@@ -1,11 +1,5 @@
 /* global NotificationFx */
 
-/* MagicMirror²
- * Module: alert
- *
- * By Paul-Vincent Roll https://paulvincentroll.com/
- * MIT Licensed.
- */
 Module.register("alert", {
 	alerts: {},
 

--- a/modules/default/alert/notificationFx.js
+++ b/modules/default/alert/notificationFx.js
@@ -1,16 +1,3 @@
-/**
- * Based on work by
- *
- * notificationFx.js v1.0.0
- * https://tympanus.net/codrops/
- *
- * Licensed under the MIT license.
- * https://opensource.org/licenses/mit-license.php
- *
- * Copyright 2014, Codrops
- * https://tympanus.net/codrops/
- * @param {object} window The window object
- */
 (function (window) {
 
 	/**

--- a/modules/default/alert/notificationFx.js
+++ b/modules/default/alert/notificationFx.js
@@ -1,3 +1,16 @@
+/**
+ * Based on work by
+ *
+ * notificationFx.js v1.0.0
+ * https://tympanus.net/codrops/
+ *
+ * Licensed under the MIT license.
+ * https://opensource.org/licenses/mit-license.php
+ *
+ * Copyright 2014, Codrops
+ * https://tympanus.net/codrops/
+ * @param {object} window The window object
+ */
 (function (window) {
 
 	/**

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -1,11 +1,5 @@
 /* global CalendarUtils */
 
-/* MagicMirror²
- * Module: Calendar
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
 Module.register("calendar", {
 	// Define module defaults
 	defaults: {

--- a/modules/default/calendar/calendarfetcher.js
+++ b/modules/default/calendar/calendarfetcher.js
@@ -1,10 +1,3 @@
-/* MagicMirror²
- * Node Helper: Calendar - CalendarFetcher
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
-
 const https = require("node:https");
 const ical = require("node-ical");
 const Log = require("logger");

--- a/modules/default/calendar/calendarfetcherutils.js
+++ b/modules/default/calendar/calendarfetcherutils.js
@@ -1,10 +1,3 @@
-/* MagicMirror²
- * Calendar Fetcher Util Methods
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
-
 /**
  * @external Moment
  */

--- a/modules/default/calendar/calendarutils.js
+++ b/modules/default/calendar/calendarutils.js
@@ -1,9 +1,3 @@
-/* MagicMirror²
- * Calendar Util Methods
- *
- * By Rejas
- * MIT Licensed.
- */
 const CalendarUtils = {
 
 	/**

--- a/modules/default/calendar/debug.js
+++ b/modules/default/calendar/debug.js
@@ -1,9 +1,6 @@
 /* CalendarFetcher Tester
  * use this script with `node debug.js` to test the fetcher without the need
  * of starting the MagicMirror² core. Adjust the values below to your desire.
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
  */
 // Alias modules mentioned in package.js under _moduleAliases.
 require("module-alias/register");

--- a/modules/default/calendar/node_helper.js
+++ b/modules/default/calendar/node_helper.js
@@ -1,9 +1,3 @@
-/* MagicMirror²
- * Node Helper: Calendar
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
 const NodeHelper = require("node_helper");
 const Log = require("logger");
 const CalendarFetcher = require("./calendarfetcher");

--- a/modules/default/clock/clock.js
+++ b/modules/default/clock/clock.js
@@ -1,11 +1,5 @@
 /* global SunCalc, formatTime */
 
-/* MagicMirror²
- * Module: Clock
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
 Module.register("clock", {
 	// Module config defaults.
 	defaults: {

--- a/modules/default/compliments/compliments.js
+++ b/modules/default/compliments/compliments.js
@@ -1,9 +1,3 @@
-/* MagicMirror²
- * Module: Compliments
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
 Module.register("compliments", {
 	// Module config defaults.
 	defaults: {

--- a/modules/default/defaultmodules.js
+++ b/modules/default/defaultmodules.js
@@ -1,9 +1,3 @@
-/* MagicMirror² Default Modules List
- * Modules listed below can be loaded without the 'default/' prefix. Omitting the default folder name.
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
 const defaultModules = ["alert", "calendar", "clock", "compliments", "helloworld", "newsfeed", "updatenotification", "weather"];
 
 /*************** DO NOT EDIT THE LINE BELOW ***************/

--- a/modules/default/defaultmodules.js
+++ b/modules/default/defaultmodules.js
@@ -1,3 +1,6 @@
+/* Default Modules List
+ * Modules listed below can be loaded without the 'default/' prefix. Omitting the default folder name.
+ */
 const defaultModules = ["alert", "calendar", "clock", "compliments", "helloworld", "newsfeed", "updatenotification", "weather"];
 
 /*************** DO NOT EDIT THE LINE BELOW ***************/

--- a/modules/default/helloworld/helloworld.js
+++ b/modules/default/helloworld/helloworld.js
@@ -1,9 +1,3 @@
-/* MagicMirror²
- * Module: HelloWorld
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
 Module.register("helloworld", {
 	// Default module config.
 	defaults: {

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -1,9 +1,3 @@
-/* MagicMirror²
- * Module: NewsFeed
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
 Module.register("newsfeed", {
 	// Default module config.
 	defaults: {

--- a/modules/default/newsfeed/newsfeedfetcher.js
+++ b/modules/default/newsfeed/newsfeedfetcher.js
@@ -1,10 +1,3 @@
-/* MagicMirror²
- * Node Helper: Newsfeed - NewsfeedFetcher
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
-
 const crypto = require("node:crypto");
 const stream = require("node:stream");
 const FeedMe = require("feedme");

--- a/modules/default/newsfeed/node_helper.js
+++ b/modules/default/newsfeed/node_helper.js
@@ -1,10 +1,3 @@
-/* MagicMirror²
- * Node Helper: Newsfeed
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
-
 const NodeHelper = require("node_helper");
 const Log = require("logger");
 const NewsfeedFetcher = require("./newsfeedfetcher");

--- a/modules/default/updatenotification/updatenotification.js
+++ b/modules/default/updatenotification/updatenotification.js
@@ -1,9 +1,3 @@
-/* MagicMirror²
- * Module: UpdateNotification
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
 Module.register("updatenotification", {
 	defaults: {
 		updateInterval: 10 * 60 * 1000, // every 10 minutes

--- a/modules/default/weather/providers/envcanada.js
+++ b/modules/default/weather/providers/envcanada.js
@@ -1,39 +1,5 @@
 /* global WeatherProvider, WeatherObject, WeatherUtils */
 
-/* MagicMirror²
- * Module: Weather
- * Provider: Environment Canada (EC)
- *
- * This class is a provider for Environment Canada MSC Datamart
- * Note that this is only for Canadian locations and does not require an API key (access is anonymous)
- *
- * EC Documentation at following links:
- * 	https://dd.weather.gc.ca/citypage_weather/schema/
- * 	https://eccc-msc.github.io/open-data/msc-datamart/readme_en/
- *
- * This module supports Canadian locations only and requires 2 additional config parameters:
- *
- * siteCode - the city/town unique identifier for which weather is to be displayed. Format is 's0000000'.
- *
- * provCode - the 2-character province code for the selected city/town.
- *
- * Example: for Toronto, Ontario, the following parameters would be used
- *
- * siteCode: 's0000458',
- * provCode: 'ON'
- *
- * To determine the siteCode and provCode values for a Canadian city/town, look at the Environment Canada document
- * at https://dd.weather.gc.ca/citypage_weather/docs/site_list_en.csv (or site_list_fr.csv). There you will find a table
- * with locations you can search under column B (English Names), with the corresponding siteCode under
- * column A (Codes) and provCode under column C (Province).
- *
- * Original by Kevin Godin
- *
- * License to use Environment Canada (EC) data is detailed here:
- * 	https://eccc-msc.github.io/open-data/licence/readme_en/
- *
- */
-
 WeatherProvider.register("envcanada", {
 	// Set the name of the provider for debugging and alerting purposes (eg. provide eye-catcher)
 	providerName: "Environment Canada",

--- a/modules/default/weather/providers/envcanada.js
+++ b/modules/default/weather/providers/envcanada.js
@@ -1,5 +1,33 @@
 /* global WeatherProvider, WeatherObject, WeatherUtils */
 
+/* This class is a provider for Environment Canada MSC Datamart
+ * Note that this is only for Canadian locations and does not require an API key (access is anonymous)
+ *
+ * EC Documentation at following links:
+ * 	https://dd.weather.gc.ca/citypage_weather/schema/
+ * 	https://eccc-msc.github.io/open-data/msc-datamart/readme_en/
+ *
+ * This module supports Canadian locations only and requires 2 additional config parameters:
+ *
+ * siteCode - the city/town unique identifier for which weather is to be displayed. Format is 's0000000'.
+ *
+ * provCode - the 2-character province code for the selected city/town.
+ *
+ * Example: for Toronto, Ontario, the following parameters would be used
+ *
+ * siteCode: 's0000458',
+ * provCode: 'ON'
+ *
+ * To determine the siteCode and provCode values for a Canadian city/town, look at the Environment Canada document
+ * at https://dd.weather.gc.ca/citypage_weather/docs/site_list_en.csv (or site_list_fr.csv). There you will find a table
+ * with locations you can search under column B (English Names), with the corresponding siteCode under
+ * column A (Codes) and provCode under column C (Province).
+ *
+ * License to use Environment Canada (EC) data is detailed here:
+ * 	https://eccc-msc.github.io/open-data/licence/readme_en/
+ *
+ */
+
 WeatherProvider.register("envcanada", {
 	// Set the name of the provider for debugging and alerting purposes (eg. provide eye-catcher)
 	providerName: "Environment Canada",

--- a/modules/default/weather/providers/openmeteo.js
+++ b/modules/default/weather/providers/openmeteo.js
@@ -1,5 +1,9 @@
 /* global WeatherProvider, WeatherObject */
 
+/* This class is a provider for Open-Meteo,
+ * see https://open-meteo.com/
+ */
+
 // https://www.bigdatacloud.com/docs/api/free-reverse-geocode-to-city-api
 const GEOCODE_BASE = "https://api.bigdatacloud.net/data/reverse-geocode-client";
 const OPEN_METEO_BASE = "https://api.open-meteo.com/v1";

--- a/modules/default/weather/providers/openmeteo.js
+++ b/modules/default/weather/providers/openmeteo.js
@@ -1,15 +1,5 @@
 /* global WeatherProvider, WeatherObject */
 
-/* MagicMirror²
- * Module: Weather
- * Provider: Open-Meteo
- *
- * By Andrés Vanegas
- * MIT Licensed
- *
- * This class is a provider for Open-Meteo, based on Andrew Pometti's class
- * for Weatherbit.
- */
 // https://www.bigdatacloud.com/docs/api/free-reverse-geocode-to-city-api
 const GEOCODE_BASE = "https://api.bigdatacloud.net/data/reverse-geocode-client";
 const OPEN_METEO_BASE = "https://api.open-meteo.com/v1";

--- a/modules/default/weather/providers/openweathermap.js
+++ b/modules/default/weather/providers/openweathermap.js
@@ -1,13 +1,5 @@
 /* global WeatherProvider, WeatherObject */
 
-/* MagicMirror²
- * Module: Weather
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- *
- * This class is the blueprint for a weather provider.
- */
 WeatherProvider.register("openweathermap", {
 	// Set the name of the provider.
 	// This isn't strictly necessary, since it will fallback to the provider identifier

--- a/modules/default/weather/providers/openweathermap.js
+++ b/modules/default/weather/providers/openweathermap.js
@@ -1,5 +1,8 @@
 /* global WeatherProvider, WeatherObject */
 
+/* This class is a provider for Openweathermap,
+ * see https://openweathermap.org/
+ */
 WeatherProvider.register("openweathermap", {
 	// Set the name of the provider.
 	// This isn't strictly necessary, since it will fallback to the provider identifier

--- a/modules/default/weather/providers/pirateweather.js
+++ b/modules/default/weather/providers/pirateweather.js
@@ -1,15 +1,5 @@
 /* global WeatherProvider, WeatherObject */
 
-/* MagicMirror²
- * Module: Weather
- * Provider: Pirate Weather
- *
- * Written by Nicholas Hubbard https://github.com/nhubbard for formerly Dark Sky Provider
- * Modified by Karsten Hassel for Pirate Weather
- * MIT Licensed
- *
- * This class is a provider for Pirate Weather, it is a replacement for Dark Sky (same api).
- */
 WeatherProvider.register("pirateweather", {
 	// Set the name of the provider.
 	// Not strictly required, but helps for debugging.

--- a/modules/default/weather/providers/pirateweather.js
+++ b/modules/default/weather/providers/pirateweather.js
@@ -1,5 +1,8 @@
 /* global WeatherProvider, WeatherObject */
 
+/* This class is a provider for Pirate Weather, it is a replacement for Dark Sky (same api),
+ * see http://pirateweather.net/en/latest/
+ */
 WeatherProvider.register("pirateweather", {
 	// Set the name of the provider.
 	// Not strictly required, but helps for debugging.

--- a/modules/default/weather/providers/smhi.js
+++ b/modules/default/weather/providers/smhi.js
@@ -1,15 +1,5 @@
 /* global WeatherProvider, WeatherObject */
 
-/* MagicMirror²
- * Module: Weather
- * Provider: SMHI
- *
- * By BuXXi https://github.com/buxxi
- * MIT Licensed
- *
- * This class is a provider for SMHI (Sweden only). Metric system is the only
- * supported unit.
- */
 WeatherProvider.register("smhi", {
 	providerName: "SMHI",
 

--- a/modules/default/weather/providers/smhi.js
+++ b/modules/default/weather/providers/smhi.js
@@ -1,5 +1,9 @@
 /* global WeatherProvider, WeatherObject */
 
+/* This class is a provider for SMHI (Sweden only).
+ * Metric system is the only supported unit,
+ * see https://www.smhi.se/
+ */
 WeatherProvider.register("smhi", {
 	providerName: "SMHI",
 

--- a/modules/default/weather/providers/ukmetoffice.js
+++ b/modules/default/weather/providers/ukmetoffice.js
@@ -1,5 +1,8 @@
 /* global WeatherProvider, WeatherObject, WeatherUtils */
 
+/* This class is a provider for UK Met Office Datapoint,
+ * see https://www.metoffice.gov.uk/
+ */
 WeatherProvider.register("ukmetoffice", {
 	// Set the name of the provider.
 	// This isn't strictly necessary, since it will fallback to the provider identifier

--- a/modules/default/weather/providers/ukmetoffice.js
+++ b/modules/default/weather/providers/ukmetoffice.js
@@ -1,13 +1,5 @@
 /* global WeatherProvider, WeatherObject, WeatherUtils */
 
-/* MagicMirror²
- * Module: Weather
- *
- * By Malcolm Oakes https://github.com/maloakes
- * MIT Licensed.
- *
- * This class is a provider for UK Met Office Datapoint.
- */
 WeatherProvider.register("ukmetoffice", {
 	// Set the name of the provider.
 	// This isn't strictly necessary, since it will fallback to the provider identifier

--- a/modules/default/weather/providers/ukmetofficedatahub.js
+++ b/modules/default/weather/providers/ukmetofficedatahub.js
@@ -1,5 +1,37 @@
 /* global WeatherProvider, WeatherObject */
 
+/* This class is a provider for UK Met Office Data Hub (the replacement for their Data Point services).
+ * For more information on Data Hub, see https://www.metoffice.gov.uk/services/data/datapoint/notifications/weather-datahub
+ * Data available:
+ * 		Hourly data for next 2 days ("hourly") - https://www.metoffice.gov.uk/binaries/content/assets/metofficegovuk/pdf/data/global-spot-data-hourly.pdf
+ * 		3-hourly data for the next 7 days ("3hourly") - https://www.metoffice.gov.uk/binaries/content/assets/metofficegovuk/pdf/data/global-spot-data-3-hourly.pdf
+ * 		Daily data for the next 7 days ("daily") - https://www.metoffice.gov.uk/binaries/content/assets/metofficegovuk/pdf/data/global-spot-data-daily.pdf
+ *
+ * NOTES
+ * This provider requires longitude/latitude coordinates, rather than a location ID (as with the previous Met Office provider)
+ * Provide the following in your config.js file:
+ * 		weatherProvider: "ukmetofficedatahub",
+ * 		apiBase: "https://api-metoffice.apiconnect.ibmcloud.com/metoffice/production/v0/forecasts/point/",
+ * 		apiKey: "[YOUR API KEY]",
+ * 		apiSecret: "[YOUR API SECRET]",
+ * 		lat: [LATITUDE (DECIMAL)],
+ * 		lon: [LONGITUDE (DECIMAL)]
+ *
+ * At time of writing, free accounts are limited to 360 requests a day per service (hourly, 3hourly, daily); take this in mind when
+ * setting your update intervals. For reference, 360 requests per day is once every 4 minutes.
+ *
+ * Pay attention to the units of the supplied data from the Met Office - it is given in SI/metric units where applicable:
+ * 	- Temperatures are in degrees Celsius (°C)
+ * 	- Wind speeds are in metres per second (m/s)
+ * 	- Wind direction given in degrees (°)
+ * 	- Pressures are in Pascals (Pa)
+ * 	- Distances are in metres (m)
+ * 	- Probabilities and humidity are given as percentages (%)
+ * 	- Precipitation is measured in millimetres (mm) with rates per hour (mm/h)
+ *
+ * See the PDFs linked above for more information on the data their corresponding units.
+ */
+
 WeatherProvider.register("ukmetofficedatahub", {
 	// Set the name of the provider.
 	providerName: "UK Met Office (DataHub)",

--- a/modules/default/weather/providers/ukmetofficedatahub.js
+++ b/modules/default/weather/providers/ukmetofficedatahub.js
@@ -1,44 +1,5 @@
 /* global WeatherProvider, WeatherObject */
 
-/* MagicMirror²
- * Module: Weather
- *
- * By Malcolm Oakes https://github.com/maloakes
- * Existing Met Office provider edited for new MetOffice Data Hub by CreepinJesus http://github.com/XBCreepinJesus
- * MIT Licensed.
- *
- * This class is a provider for UK Met Office Data Hub (the replacement for their Data Point services).
- * For more information on Data Hub, see https://www.metoffice.gov.uk/services/data/datapoint/notifications/weather-datahub
- * Data available:
- * 		Hourly data for next 2 days ("hourly") - https://www.metoffice.gov.uk/binaries/content/assets/metofficegovuk/pdf/data/global-spot-data-hourly.pdf
- * 		3-hourly data for the next 7 days ("3hourly") - https://www.metoffice.gov.uk/binaries/content/assets/metofficegovuk/pdf/data/global-spot-data-3-hourly.pdf
- * 		Daily data for the next 7 days ("daily") - https://www.metoffice.gov.uk/binaries/content/assets/metofficegovuk/pdf/data/global-spot-data-daily.pdf
- *
- * NOTES
- * This provider requires longitude/latitude coordinates, rather than a location ID (as with the previous Met Office provider)
- * Provide the following in your config.js file:
- * 		weatherProvider: "ukmetofficedatahub",
- * 		apiBase: "https://api-metoffice.apiconnect.ibmcloud.com/metoffice/production/v0/forecasts/point/",
- * 		apiKey: "[YOUR API KEY]",
- * 		apiSecret: "[YOUR API SECRET]",
- * 		lat: [LATITUDE (DECIMAL)],
- * 		lon: [LONGITUDE (DECIMAL)]
- *
- * At time of writing, free accounts are limited to 360 requests a day per service (hourly, 3hourly, daily); take this in mind when
- * setting your update intervals. For reference, 360 requests per day is once every 4 minutes.
- *
- * Pay attention to the units of the supplied data from the Met Office - it is given in SI/metric units where applicable:
- * 	- Temperatures are in degrees Celsius (°C)
- * 	- Wind speeds are in metres per second (m/s)
- * 	- Wind direction given in degrees (°)
- * 	- Pressures are in Pascals (Pa)
- * 	- Distances are in metres (m)
- * 	- Probabilities and humidity are given as percentages (%)
- * 	- Precipitation is measured in millimetres (mm) with rates per hour (mm/h)
- *
- * See the PDFs linked above for more information on the data their corresponding units.
- */
-
 WeatherProvider.register("ukmetofficedatahub", {
 	// Set the name of the provider.
 	providerName: "UK Met Office (DataHub)",

--- a/modules/default/weather/providers/weatherbit.js
+++ b/modules/default/weather/providers/weatherbit.js
@@ -1,5 +1,8 @@
 /* global WeatherProvider, WeatherObject */
 
+/* This class is a provider for Weatherbit,
+ * see https://www.weatherbit.io/
+ */
 WeatherProvider.register("weatherbit", {
 	// Set the name of the provider.
 	// Not strictly required, but helps for debugging.

--- a/modules/default/weather/providers/weatherbit.js
+++ b/modules/default/weather/providers/weatherbit.js
@@ -1,15 +1,5 @@
 /* global WeatherProvider, WeatherObject */
 
-/* MagicMirror²
- * Module: Weather
- * Provider: Weatherbit
- *
- * By Andrew Pometti
- * MIT Licensed
- *
- * This class is a provider for Weatherbit, based on Nicholas Hubbard's class
- * for Dark Sky & Vince Peri's class for Weather.gov.
- */
 WeatherProvider.register("weatherbit", {
 	// Set the name of the provider.
 	// Not strictly required, but helps for debugging.

--- a/modules/default/weather/providers/weatherflow.js
+++ b/modules/default/weather/providers/weatherflow.js
@@ -1,16 +1,5 @@
 /* global WeatherProvider, WeatherObject, WeatherUtils */
 
-/* MagicMirror²
- * Module: Weather
- * Provider: Weatherflow
- *
- * By Tobias Dreyem https://github.com/10bias
- * MIT Licensed
- *
- * This class is a provider for Weatherflow.
- * Note that the Weatherflow API does not provide snowfall.
- */
-
 WeatherProvider.register("weatherflow", {
 	// Set the name of the provider.
 	// Not strictly required, but helps for debugging

--- a/modules/default/weather/providers/weatherflow.js
+++ b/modules/default/weather/providers/weatherflow.js
@@ -1,5 +1,8 @@
 /* global WeatherProvider, WeatherObject, WeatherUtils */
 
+/* This class is a provider for Weatherflow.
+ * Note that the Weatherflow API does not provide snowfall.
+ */
 WeatherProvider.register("weatherflow", {
 	// Set the name of the provider.
 	// Not strictly required, but helps for debugging

--- a/modules/default/weather/providers/weathergov.js
+++ b/modules/default/weather/providers/weathergov.js
@@ -1,5 +1,13 @@
 /* global WeatherProvider, WeatherObject, WeatherUtils */
 
+/* Provider: weather.gov
+ * https://weather-gov.github.io/api/general-faqs
+ *
+ * This class is a provider for weather.gov.
+ * Note that this is only for US locations (lat and lon) and does not require an API key
+ * Since it is free, there are some items missing - like sunrise, sunset
+ */
+
 WeatherProvider.register("weathergov", {
 	// Set the name of the provider.
 	// This isn't strictly necessary, since it will fallback to the provider identifier

--- a/modules/default/weather/providers/weathergov.js
+++ b/modules/default/weather/providers/weathergov.js
@@ -1,18 +1,5 @@
 /* global WeatherProvider, WeatherObject, WeatherUtils */
 
-/* MagicMirror²
- * Module: Weather
- * Provider: weather.gov
- * https://weather-gov.github.io/api/general-faqs
- *
- * Original by Vince Peri
- * MIT Licensed.
- *
- * This class is a provider for weather.gov.
- * Note that this is only for US locations (lat and lon) and does not require an API key
- * Since it is free, there are some items missing - like sunrise, sunset
- */
-
 WeatherProvider.register("weathergov", {
 	// Set the name of the provider.
 	// This isn't strictly necessary, since it will fallback to the provider identifier

--- a/modules/default/weather/providers/yr.js
+++ b/modules/default/weather/providers/yr.js
@@ -1,5 +1,8 @@
 /* global WeatherProvider, WeatherObject */
 
+/* This class is a provider for Yr.no, a norwegian weather service.
+ * Terms of service: https://developer.yr.no/doc/TermsOfService/
+ */
 WeatherProvider.register("yr", {
 	providerName: "Yr",
 

--- a/modules/default/weather/providers/yr.js
+++ b/modules/default/weather/providers/yr.js
@@ -1,16 +1,5 @@
 /* global WeatherProvider, WeatherObject */
 
-/* MagicMirror²
- * Module: Weather
- * Provider: Yr.no
- *
- * By Magnus Marthinsen
- * MIT Licensed
- *
- * This class is a provider for Yr.no, a norwegian weather service.
- *
- * Terms of service: https://developer.yr.no/doc/TermsOfService/
- */
 WeatherProvider.register("yr", {
 	providerName: "Yr",
 

--- a/modules/default/weather/weather.js
+++ b/modules/default/weather/weather.js
@@ -1,11 +1,5 @@
 /* global WeatherProvider, WeatherUtils, formatTime */
 
-/* MagicMirror²
- * Module: Weather
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
 Module.register("weather", {
 	// Default module config.
 	defaults: {

--- a/modules/default/weather/weatherobject.js
+++ b/modules/default/weather/weatherobject.js
@@ -1,17 +1,5 @@
 /* global SunCalc, WeatherUtils */
 
-/* MagicMirror²
- * Module: Weather
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- *
- * This class is the blueprint for a day which includes weather information.
- *
- * Currently this is focused on the information which is necessary for the current weather.
- * As soon as we start implementing the forecast, mode properties will be added.
- */
-
 /**
  * @external Moment
  */

--- a/modules/default/weather/weatherprovider.js
+++ b/modules/default/weather/weatherprovider.js
@@ -1,13 +1,5 @@
 /* global Class, performWebRequest, OverrideWrapper */
 
-/* MagicMirror²
- * Module: Weather
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- *
- * This class is the blueprint for a weather provider.
- */
 const WeatherProvider = Class.extend({
 	// Weather Provider Properties
 	providerName: null,

--- a/modules/default/weather/weatherprovider.js
+++ b/modules/default/weather/weatherprovider.js
@@ -1,5 +1,6 @@
 /* global Class, performWebRequest, OverrideWrapper */
 
+// This class is the blueprint for a weather provider.
 const WeatherProvider = Class.extend({
 	// Weather Provider Properties
 	providerName: null,

--- a/modules/default/weather/weatherutils.js
+++ b/modules/default/weather/weatherutils.js
@@ -1,9 +1,3 @@
-/* MagicMirror²
- * Weather Util Methods
- *
- * By Rejas
- * MIT Licensed.
- */
 const WeatherUtils = {
 
 	/**

--- a/tests/configs/default.js
+++ b/tests/configs/default.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test default config for modules
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 exports.configFactory = (options) => {
 	return Object.assign(
 		{

--- a/tests/configs/empty_ipWhiteList.js
+++ b/tests/configs/empty_ipWhiteList.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config sample ipWhitelist
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = require(`${process.cwd()}/tests/configs/default.js`).configFactory({
 	ipWhitelist: [],
 	port: 8282

--- a/tests/configs/modules/alert/default.js
+++ b/tests/configs/modules/alert/default.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config sample module alert
- *
- * By rejas
- * MIT Licensed.
- */
 let config = {
 	modules: [
 		{

--- a/tests/configs/modules/calendar/auth-default.js
+++ b/tests/configs/modules/calendar/auth-default.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config default calendar with auth by default
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/calendar/bad_rrule.js
+++ b/tests/configs/modules/calendar/bad_rrule.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test ics with out of date event causing bad return from rrule.between
- *
- * By Sam Detweiler
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 	logLevel: ["INFO", "LOG", "WARN", "ERROR", "DEBUG"],

--- a/tests/configs/modules/calendar/basic-auth.js
+++ b/tests/configs/modules/calendar/basic-auth.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config default calendar
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/calendar/changed-port.js
+++ b/tests/configs/modules/calendar/changed-port.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config default calendar with auth by default
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/calendar/custom.js
+++ b/tests/configs/modules/calendar/custom.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config custom calendar
- *
- * By Rejas
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/calendar/default.js
+++ b/tests/configs/modules/calendar/default.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config default calendar
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/calendar/exdate.js
+++ b/tests/configs/modules/calendar/exdate.js
@@ -1,3 +1,9 @@
+/* NOTE: calendar_test_exdate.ics has exdate entries for the next 20 years, but without some
+ * way to set a debug date for tests, this test may become flaky on specific days (i.e. could
+ * not test easily on leap-years, the BYDAY specified in exdate, etc.) or when the 20 years
+ * elapses if this project is still in active development ;)
+ * See issue #3250
+ */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/calendar/exdate.js
+++ b/tests/configs/modules/calendar/exdate.js
@@ -1,14 +1,3 @@
-/* MagicMirror² Test calendar exdate
- *
- * By jkriegshauser
- * MIT Licensed.
- *
- * NOTE: calendar_test_exdate.ics has exdate entries for the next 20 years, but without some
- * way to set a debug date for tests, this test may become flaky on specific days (i.e. could
- * not test easily on leap-years, the BYDAY specified in exdate, etc.) or when the 20 years
- * elapses if this project is still in active development ;)
- * See issue #3250
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/calendar/fail-basic-auth.js
+++ b/tests/configs/modules/calendar/fail-basic-auth.js
@@ -1,10 +1,3 @@
-/* MagicMirror² Test calendar calendar
- *
- * This configuration is a wrong authentication
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/calendar/old-basic-auth.js
+++ b/tests/configs/modules/calendar/old-basic-auth.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config default calendar
- *              with authentication old config
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/calendar/recurring.js
+++ b/tests/configs/modules/calendar/recurring.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config custom calendar
- *
- * By Rejas
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/calendar/show-duplicates-in-calendar.js
+++ b/tests/configs/modules/calendar/show-duplicates-in-calendar.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config for multiple calendar events having the same name and start date/time
- *
- * By Paranoid93 https://github.com/Paranoid93/
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/clock/clock_12hr.js
+++ b/tests/configs/modules/clock/clock_12hr.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config for default clock module
- *
- * By Sergey Morozov
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/clock/clock_24hr.js
+++ b/tests/configs/modules/clock/clock_24hr.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config for default clock module
- *
- * By Sergey Morozov
- * MIT Licensed.
- */
 let config = {
 	modules: [
 		{

--- a/tests/configs/modules/clock/clock_analog.js
+++ b/tests/configs/modules/clock/clock_analog.js
@@ -1,7 +1,3 @@
-/* MagicMirror² Test config for analog clock face
- *
- * MIT Licensed.
- */
 let config = {
 	modules: [
 		{

--- a/tests/configs/modules/clock/clock_displaySeconds_false.js
+++ b/tests/configs/modules/clock/clock_displaySeconds_false.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config for default clock module
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/clock/clock_showDateAnalog.js
+++ b/tests/configs/modules/clock/clock_showDateAnalog.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config for default clock module
- *
- * By Johan Hammar
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/clock/clock_showPeriodUpper.js
+++ b/tests/configs/modules/clock/clock_showPeriodUpper.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config for default clock module
- *
- * By Sergey Morozov
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/clock/clock_showSunMoon.js
+++ b/tests/configs/modules/clock/clock_showSunMoon.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config for default clock module
- *
- * By Johan Hammar
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/clock/clock_showTime.js
+++ b/tests/configs/modules/clock/clock_showTime.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config for default clock module
- *
- * By Johan Hammar
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/clock/clock_showWeek.js
+++ b/tests/configs/modules/clock/clock_showWeek.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config for default clock module
- *
- * By Johan Hammar
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/clock/es/clock_12hr.js
+++ b/tests/configs/modules/clock/es/clock_12hr.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config for default clock module
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = {
 	language: "es",
 	timeFormat: 12,

--- a/tests/configs/modules/clock/es/clock_24hr.js
+++ b/tests/configs/modules/clock/es/clock_24hr.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config for default clock module
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = {
 	language: "es",
 

--- a/tests/configs/modules/clock/es/clock_showPeriodUpper.js
+++ b/tests/configs/modules/clock/es/clock_showPeriodUpper.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config for default clock module
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = {
 	language: "es",
 	timeFormat: 12,

--- a/tests/configs/modules/clock/es/clock_showWeek.js
+++ b/tests/configs/modules/clock/es/clock_showWeek.js
@@ -1,9 +1,3 @@
-/* MagicMirror² Test config for default clock module
- * Language es for showWeek feature
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = {
 	language: "es",
 	timeFormat: 12,

--- a/tests/configs/modules/compliments/compliments_animateCSS.js
+++ b/tests/configs/modules/compliments/compliments_animateCSS.js
@@ -1,9 +1,3 @@
-/* MagicMirror² Test config sample for AnimateCSS integration with compliments module
- *
- * By bugsounet https://github.com/bugsounet
- * 09/2023
- * MIT Licensed.
- */
 let config = {
 	modules: [
 		{

--- a/tests/configs/modules/compliments/compliments_animateCSS_fallbackToDefault.js
+++ b/tests/configs/modules/compliments/compliments_animateCSS_fallbackToDefault.js
@@ -1,10 +1,3 @@
-/* MagicMirror² Test config sample for AnimateCSS integration with compliments module
- * --> if animation name is not an AnimateCSS animation
- * --> must fallback to default (no animation)
- * By bugsounet https://github.com/bugsounet
- * 09/2023
- * MIT Licensed.
- */
 let config = {
 	modules: [
 		{

--- a/tests/configs/modules/compliments/compliments_animateCSS_invertedAnimationName.js
+++ b/tests/configs/modules/compliments/compliments_animateCSS_invertedAnimationName.js
@@ -1,9 +1,3 @@
-/* MagicMirror² Test config sample for AnimateCSS integration with compliments module
- * --> inversed name animation : in for out and vice versa (must return no animation)
- * By bugsounet https://github.com/bugsounet
- * 09/2023
- * MIT Licensed.
- */
 let config = {
 	modules: [
 		{

--- a/tests/configs/modules/compliments/compliments_anytime.js
+++ b/tests/configs/modules/compliments/compliments_anytime.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config compliments with anytime type
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/compliments/compliments_date.js
+++ b/tests/configs/modules/compliments/compliments_date.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config compliments with date type
- *
- * By Rejas
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/compliments/compliments_only_anytime.js
+++ b/tests/configs/modules/compliments/compliments_only_anytime.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config compliments with anytime type
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/compliments/compliments_parts_day.js
+++ b/tests/configs/modules/compliments/compliments_parts_day.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config for default compliments
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/compliments/compliments_remote.js
+++ b/tests/configs/modules/compliments/compliments_remote.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config compliments with remote file
- *
- * By Rejas
- * MIT Licensed.
- */
 let config = {
 	modules: [
 		{

--- a/tests/configs/modules/display.js
+++ b/tests/configs/modules/display.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config for display setters module using the helloworld module
- *
- * By Rejas
- * MIT Licensed.
- */
 let config = {
 	modules: [
 		{

--- a/tests/configs/modules/helloworld/helloworld.js
+++ b/tests/configs/modules/helloworld/helloworld.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config sample module hello world
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = {
 	modules: [
 		{

--- a/tests/configs/modules/helloworld/helloworld_default.js
+++ b/tests/configs/modules/helloworld/helloworld_default.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config sample module hello world default config
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = {
 	modules: [
 		{

--- a/tests/configs/modules/newsfeed/default.js
+++ b/tests/configs/modules/newsfeed/default.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config newsfeed module
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/newsfeed/ignore_items.js
+++ b/tests/configs/modules/newsfeed/ignore_items.js
@@ -1,7 +1,3 @@
-/* MagicMirror² Test config newsfeed module
- *
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/newsfeed/incorrect_url.js
+++ b/tests/configs/modules/newsfeed/incorrect_url.js
@@ -1,7 +1,3 @@
-/* MagicMirror² Test config newsfeed module
- *
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/newsfeed/prohibited_words.js
+++ b/tests/configs/modules/newsfeed/prohibited_words.js
@@ -1,7 +1,3 @@
-/* MagicMirror² Test config newsfeed module
- *
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/positions.js
+++ b/tests/configs/modules/positions.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config for position setters module using the helloworld module
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = {
 	modules:
 		// Using exotic content. This is why don't accept go to JSON configuration file

--- a/tests/configs/modules/weather/currentweather_compliments.js
+++ b/tests/configs/modules/weather/currentweather_compliments.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config current weather compliments
- *
- * By rejas https://github.com/rejas
- * MIT Licensed.
- */
 let config = {
 	modules: [
 		{

--- a/tests/configs/modules/weather/currentweather_default.js
+++ b/tests/configs/modules/weather/currentweather_default.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config default weather
- *
- * By fewieden https://github.com/fewieden
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/weather/currentweather_options.js
+++ b/tests/configs/modules/weather/currentweather_options.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config default weather
- *
- * By fewieden https://github.com/fewieden
- * MIT Licensed.
- */
 let config = {
 	modules: [
 		{

--- a/tests/configs/modules/weather/currentweather_units.js
+++ b/tests/configs/modules/weather/currentweather_units.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config default weather
- *
- * By fewieden https://github.com/fewieden
- * MIT Licensed.
- */
 let config = {
 	units: "imperial",
 

--- a/tests/configs/modules/weather/forecastweather_absolute.js
+++ b/tests/configs/modules/weather/forecastweather_absolute.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config default weather
- *
- * By fewieden https://github.com/fewieden
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/weather/forecastweather_default.js
+++ b/tests/configs/modules/weather/forecastweather_default.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config default weather
- *
- * By fewieden https://github.com/fewieden
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/weather/forecastweather_options.js
+++ b/tests/configs/modules/weather/forecastweather_options.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config default weather
- *
- * By fewieden https://github.com/fewieden
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/weather/forecastweather_units.js
+++ b/tests/configs/modules/weather/forecastweather_units.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config default weather
- *
- * By rejas
- * MIT Licensed.
- */
 let config = {
 	units: "imperial",
 

--- a/tests/configs/modules/weather/hourlyweather_default.js
+++ b/tests/configs/modules/weather/hourlyweather_default.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config hourly weather
- *
- * By rejas https://github.com/rejas
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/weather/hourlyweather_options.js
+++ b/tests/configs/modules/weather/hourlyweather_options.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config hourly weather options
- *
- * By rejas https://github.com/rejas
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/modules/weather/hourlyweather_showPrecipitation.js
+++ b/tests/configs/modules/weather/hourlyweather_showPrecipitation.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config hourly weather
- *
- * By rejas https://github.com/rejas
- * MIT Licensed.
- */
 let config = {
 	timeFormat: 12,
 

--- a/tests/configs/noIpWhiteList.js
+++ b/tests/configs/noIpWhiteList.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config sample ipWhitelist
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = require(`${process.cwd()}/tests/configs/default.js`).configFactory({
 	ipWhitelist: ["x.x.x.x"],
 	port: 8181

--- a/tests/configs/port_8090.js
+++ b/tests/configs/port_8090.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config sample environment set port 8090
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = require(`${process.cwd()}/tests/configs/default.js`).configFactory({
 	port: 8090
 });

--- a/tests/configs/port_variable.js.template
+++ b/tests/configs/port_variable.js.template
@@ -1,8 +1,3 @@
-/* MagicMirror² Test config sample environment set port 8090
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = require(`${process.cwd()}/tests/configs/default.js`).configFactory({
 	port: ${MM_PORT}
 });

--- a/tests/configs/without_modules.js
+++ b/tests/configs/without_modules.js
@@ -1,8 +1,3 @@
-/* MagicMirror² Test default config for modules
- *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
- * MIT Licensed.
- */
 let config = {
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1", "::ffff:192.168.10.1"]
 };

--- a/tests/e2e/animateCSS_spec.js
+++ b/tests/e2e/animateCSS_spec.js
@@ -1,10 +1,3 @@
-/* AnimateCSS integration Test with compliments module
- *
- * By bugsounet https://github.com/bugsounet
- * and helped by khassel
- * 09/2023
- * MIT Licensed.
- */
 const helpers = require("./helpers/global-setup");
 
 describe("AnimateCSS integration Test", () => {

--- a/translations/translations.js
+++ b/translations/translations.js
@@ -1,10 +1,3 @@
-/* MagicMirror²
- * Translation Definition
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
-
 let translations = {
 	en: "translations/en.json", // English
 	nl: "translations/nl.json", // Dutch

--- a/vendor/vendor.js
+++ b/vendor/vendor.js
@@ -1,9 +1,3 @@
-/* MagicMirror²
- * Vendor File Definition
- *
- * By Michael Teeuw https://michaelteeuw.nl
- * MIT Licensed.
- */
 const vendor = {
 	"moment.js": "node_modules/moment/min/moment-with-locales.js",
 	"moment-timezone.js": "node_modules/moment-timezone/builds/moment-timezone-with-data.js",


### PR DESCRIPTION
see #3358

used command: `find ./ -type f -exec perl -i -0pe 's/\/\*\s*magicmirror.*?\*\/\s*//si' {} \;`

This is a first draft, I think we should preserve some of the comments.