### PR TITLE
pm2 update ;)

### DIFF
--- a/.github/workflows/depsreview.yaml
+++ b/.github/workflows/depsreview.yaml
@@ -16,5 +16,3 @@ jobs:
         uses: actions/checkout@v4
       - name: "Dependency Review"
         uses: actions/dependency-review-action@v3
-        with:
-          allow-ghsas: GHSA-wf5p-g6vw-rhxx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ _This release is scheduled to be released on 2024-04-01._
 - Use node prefix for build-in modules (#3340)
 - Rework logging colors (#3350)
 - Update electron to v28 and update other dependencies (#3357)
+- Update pm2 to v5.3.1 with no allow-ghsas (#3364)
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
 				"module-alias": "^2.2.3",
 				"moment": "^2.30.1",
 				"node-ical": "^0.17.1",
-				"pm2": "^5.3.0",
+				"pm2": "^5.3.1",
+				"socket.io": "^4.7.4",
 				"systeminformation": "^5.21.22"
 			},
 			"devDependencies": {
@@ -1757,14 +1758,14 @@
 			"integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="
 		},
 		"node_modules/@pm2/js-api": {
-			"version": "0.6.7",
-			"resolved": "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.6.7.tgz",
-			"integrity": "sha512-jiJUhbdsK+5C4zhPZNnyA3wRI01dEc6a2GhcQ9qI38DyIk+S+C8iC3fGjcjUbt/viLYKPjlAaE+hcT2/JMQPXw==",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.8.0.tgz",
+			"integrity": "sha512-nmWzrA/BQZik3VBz+npRcNIu01kdBhWL0mxKmP1ciF/gTcujPTQqt027N9fc1pK9ERM8RipFhymw7RcmCyOEYA==",
 			"dependencies": {
 				"async": "^2.6.3",
-				"axios": "^0.21.0",
 				"debug": "~4.3.1",
 				"eventemitter2": "^6.3.1",
+				"extrareqp2": "^1.0.0",
 				"ws": "^7.0.0"
 			},
 			"engines": {
@@ -1777,14 +1778,6 @@
 			"integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
 			"dependencies": {
 				"lodash": "^4.17.14"
-			}
-		},
-		"node_modules/@pm2/js-api/node_modules/axios": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-			"integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-			"dependencies": {
-				"follow-redirects": "^1.14.0"
 			}
 		},
 		"node_modules/@pm2/js-api/node_modules/eventemitter2": {
@@ -4896,6 +4889,14 @@
 			},
 			"optionalDependencies": {
 				"@types/yauzl": "^2.9.1"
+			}
+		},
+		"node_modules/extrareqp2": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/extrareqp2/-/extrareqp2-1.0.0.tgz",
+			"integrity": "sha512-Gum0g1QYb6wpPJCVypWP3bbIuaibcFiJcpuPM10YSXp/tzqi84x9PJageob+eN4xVRIOto4wjSGNLyMD54D2xA==",
+			"dependencies": {
+				"follow-redirects": "^1.14.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -8482,13 +8483,13 @@
 			}
 		},
 		"node_modules/pm2": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/pm2/-/pm2-5.3.0.tgz",
-			"integrity": "sha512-xscmQiAAf6ArVmKhjKTeeN8+Td7ZKnuZFFPw1DGkdFPR/0Iyx+m+1+OpCdf9+HQopX3VPc9/wqPQHqVOfHum9w==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/pm2/-/pm2-5.3.1.tgz",
+			"integrity": "sha512-DLVQHpSR1EegaTaRH3KbRXxpPVaqYwAp3uHSCtCsS++LSErvk07WSxuUnntFblBRqNU/w2KQyqs12mSq5wurkg==",
 			"dependencies": {
 				"@pm2/agent": "~2.0.0",
 				"@pm2/io": "~5.0.0",
-				"@pm2/js-api": "~0.6.7",
+				"@pm2/js-api": "~0.8.0",
 				"@pm2/pm2-version-check": "latest",
 				"async": "~3.2.0",
 				"blessed": "0.1.81",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
 		"module-alias": "^2.2.3",
 		"moment": "^2.30.1",
 		"node-ical": "^0.17.1",
-		"pm2": "^5.3.0",
+		"pm2": "^5.3.1",
 		"socket.io": "^4.7.4",
 		"systeminformation": "^5.21.22"
 	},


### PR DESCRIPTION
`pm2` just updated to v5.3.1 with `0 vulnerabilities`

let's delete `allow-ghsas` in depsreview and update dependencies 
