### PR TITLE
Lint package.json files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
-modules/default/calendar/vendor/*
+modules/*
+!modules/default/

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -79,6 +79,15 @@
 			"rules": {
 				"@stylistic/quotes": "off"
 			}
+		},
+		{
+			"extends": ["plugin:package-json/recommended"],
+			"files": ["package.json"],
+			"parser": "jsonc-eslint-parser",
+			"plugins": ["package-json"],
+			"rules": {
+				"package-json/sort-collections": ["error", ["devDependencies", "dependencies", "peerDependencies", "config"]]
+			}
 		}
 	]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 *.js
+.eslintignore
 .prettierignore
 /config
 /coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _This release is scheduled to be released on 2024-04-01._
 ### Added
 
 - Output of system information to the console for troubleshooting (#3328 and #3337), ignore errors under aarch64
+- [chore] Add `eslint-plugin-package-json` to lint the `package.json` files
 
 ### Updated
 

--- a/fonts/package-lock.json
+++ b/fonts/package-lock.json
@@ -1,10 +1,12 @@
 {
 	"name": "magicmirror-fonts",
+	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "magicmirror-fonts",
+			"version": "1.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"@fontsource/roboto": "^5.0.8",

--- a/fonts/package.json
+++ b/fonts/package.json
@@ -1,10 +1,8 @@
 {
 	"name": "magicmirror-fonts",
-	"description": "Package for fonts use by MagicMirror² Core.",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/MagicMirrorOrg/MagicMirror.git"
-	},
+	"version": "1.0.0",
+	"description": "Package for fonts use by MagicMirror² core.",
+	"repository": "MagicMirrorOrg/MagicMirror",
 	"license": "MIT",
 	"bugs": {
 		"url": "https://github.com/MagicMirrorOrg/MagicMirror/issues"

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
 				"eslint-plugin-import": "^2.29.1",
 				"eslint-plugin-jest": "^27.6.3",
 				"eslint-plugin-jsdoc": "^48.0.2",
+				"eslint-plugin-package-json": "^0.10.0",
 				"eslint-plugin-unicorn": "^50.0.1",
 				"express-basic-auth": "^1.2.1",
 				"husky": "^8.0.3",
@@ -1828,6 +1829,16 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/glob": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+			"dev": true,
+			"dependencies": {
+				"@types/minimatch": "*",
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/graceful-fs": {
 			"version": "4.1.9",
 			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -1887,6 +1898,12 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
+		},
+		"node_modules/@types/minimatch": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+			"integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+			"dev": true
 		},
 		"node_modules/@types/node": {
 			"version": "18.19.7",
@@ -2656,6 +2673,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/builtins": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+			"integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^7.0.0"
+			}
+		},
 		"node_modules/bytes": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -3341,6 +3367,15 @@
 			"engines": {
 				"node": ">= 0.8",
 				"npm": "1.2.8000 || >= 1.4.16"
+			}
+		},
+		"node_modules/detect-indent": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+			"integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/detect-newline": {
@@ -4109,6 +4144,25 @@
 				"eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
 			}
 		},
+		"node_modules/eslint-plugin-package-json": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-package-json/-/eslint-plugin-package-json-0.10.0.tgz",
+			"integrity": "sha512-vUEfGptdpaEw0DTzN8Yl4cjZ2XZosuzAbZ+kOKJN+tJRe2hZDogesMhNYT8FI26QZ1rYUnfQ0wwzBTjswGr04g==",
+			"dev": true,
+			"dependencies": {
+				"package-json-validator": "^0.6.3",
+				"semver": "^7.5.4",
+				"sort-package-json": "^1.57.0",
+				"validate-npm-package-name": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"eslint": ">=8.0.0",
+				"jsonc-eslint-parser": "^2.0.0"
+			}
+		},
 		"node_modules/eslint-plugin-unicorn": {
 			"version": "50.0.1",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-50.0.1.tgz",
@@ -4839,6 +4893,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/git-hooks-list": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-1.0.3.tgz",
+			"integrity": "sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/fisker/git-hooks-list?sponsor=1"
 			}
 		},
 		"node_modules/glob": {
@@ -5601,6 +5664,15 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-plain-obj": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -6505,6 +6577,25 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/jsonc-eslint-parser": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.0.tgz",
+			"integrity": "sha512-WYDyuc/uFcGp6YtM2H0uKmUwieOuzeE/5YocFJLnLfclZ4inf3mRn8ZVy1s7Hxji7Jxm6Ss8gqpexD/GlKoGgg==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"acorn": "^8.5.0",
+				"eslint-visitor-keys": "^3.0.0",
+				"espree": "^9.0.0",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ota-meshi"
 			}
 		},
 		"node_modules/jsonfile": {
@@ -7460,6 +7551,31 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/optimist": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+			"integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
+			"dev": true,
+			"dependencies": {
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
+			}
+		},
+		"node_modules/optimist/node_modules/minimist": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+			"integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
+			"dev": true
+		},
+		"node_modules/optimist/node_modules/wordwrap": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/optionator": {
 			"version": "0.9.3",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -7520,6 +7636,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/package-json-validator": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/package-json-validator/-/package-json-validator-0.6.3.tgz",
+			"integrity": "sha512-juKiFboV4UKUvWQ+OSxstnyukhuluyuEoFmgZw1Rx21XzmwlgDWLcbl3qzjA3789IRORYhVFs7cmAO0YFGwHCg==",
+			"dev": true,
+			"dependencies": {
+				"optimist": "~0.6.0"
+			},
+			"bin": {
+				"pjv": "bin/pjv"
 			}
 		},
 		"node_modules/parent-module": {
@@ -8907,6 +9035,48 @@
 				"node": ">=10.0.0"
 			}
 		},
+		"node_modules/sort-object-keys": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
+			"integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==",
+			"dev": true
+		},
+		"node_modules/sort-package-json": {
+			"version": "1.57.0",
+			"resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.57.0.tgz",
+			"integrity": "sha512-FYsjYn2dHTRb41wqnv+uEqCUvBpK3jZcTp9rbz2qDTmel7Pmdtf+i2rLaaPMRZeSVM60V3Se31GyWFpmKs4Q5Q==",
+			"dev": true,
+			"dependencies": {
+				"detect-indent": "^6.0.0",
+				"detect-newline": "3.1.0",
+				"git-hooks-list": "1.0.3",
+				"globby": "10.0.0",
+				"is-plain-obj": "2.1.0",
+				"sort-object-keys": "^1.1.3"
+			},
+			"bin": {
+				"sort-package-json": "cli.js"
+			}
+		},
+		"node_modules/sort-package-json/node_modules/globby": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.0.tgz",
+			"integrity": "sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==",
+			"dev": true,
+			"dependencies": {
+				"@types/glob": "^7.1.1",
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.0.3",
+				"glob": "^7.1.3",
+				"ignore": "^5.1.1",
+				"merge2": "^1.2.3",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10136,6 +10306,18 @@
 			"dependencies": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/validate-npm-package-name": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
+			"integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
+			"dev": true,
+			"dependencies": {
+				"builtins": "^5.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -18,20 +18,17 @@
 		"test:e2e": "NODE_ENV=test jest --selectProjects e2e -i --forceExit",
 		"test:unit": "NODE_ENV=test jest --selectProjects unit",
 		"test:prettier": "prettier . --check",
-		"test:js": "eslint 'js/**/*.js' 'modules/default/**/*.js' 'clientonly/*.js' 'serveronly/*.js' 'translations/*.js' 'vendor/*.js' 'tests/**/*.js' 'config/*'",
+		"test:js": "eslint .",
 		"test:css": "stylelint 'css/main.css' 'fonts/*.css' 'modules/default/**/*.css' 'vendor/*.css' --config .stylelintrc.json",
 		"test:calendar": "node ./modules/default/calendar/debug.js",
 		"config:check": "node js/check_config.js",
 		"lint:prettier": "prettier . --write",
-		"lint:js": "eslint 'js/**/*.js' 'modules/default/**/*.js' 'clientonly/*.js' 'serveronly/*.js' 'translations/*.js' 'vendor/*.js' 'tests/**/*.js' 'config/*' --fix",
+		"lint:js": "eslint . --fix",
 		"lint:css": "stylelint 'css/main.css' 'fonts/*.css' 'modules/default/**/*.css' 'vendor/*.css' --config .stylelintrc.json --fix",
 		"lint:staged": "lint-staged",
 		"prepare": "[ -f node_modules/.bin/husky ] && husky install || echo no husky installed."
 	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/MagicMirrorOrg/MagicMirror.git"
-	},
+	"repository": "MagicMirrorOrg/MagicMirror",
 	"keywords": [
 		"magic mirror",
 		"magicmirror",
@@ -53,6 +50,7 @@
 		"eslint-plugin-import": "^2.29.1",
 		"eslint-plugin-jest": "^27.6.3",
 		"eslint-plugin-jsdoc": "^48.0.2",
+		"eslint-plugin-package-json": "^0.10.0",
 		"eslint-plugin-unicorn": "^50.0.1",
 		"express-basic-auth": "^1.2.1",
 		"husky": "^8.0.3",

--- a/vendor/package-lock.json
+++ b/vendor/package-lock.json
@@ -1,10 +1,12 @@
 {
 	"name": "magicmirror-vendors",
+	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "magicmirror-vendors",
+			"version": "1.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"@fortawesome/fontawesome-free": "^6.5.1",

--- a/vendor/package.json
+++ b/vendor/package.json
@@ -1,10 +1,8 @@
 {
 	"name": "magicmirror-vendors",
-	"description": "Package for vendors use by MagicMirror² Core.",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/MagicMirrorOrg/MagicMirror.git"
-	},
+	"version": "1.0.0",
+	"description": "Package for vendors use by MagicMirror² core.",
+	"repository": "MagicMirrorOrg/MagicMirror",
 	"license": "MIT",
 	"bugs": {
 		"url": "https://github.com/MagicMirrorOrg/MagicMirror/issues"


### PR DESCRIPTION
Notable changes in this context:

- simplification of the ESLint calls - there is no longer a combination of two file/directory lists (one in `package.json` and one in `.eslintignore`)
- removal of a non-existent path from the `.eslintignore`
- use shorthand declaration for GitHub repository

Normally the new plugin would also sort the scripts in the package.json alphabetically, but I think the current order is fine, so I deactivated it.

Is it overkill to introduce a linter plugin just for the `package.json` files?

In other projects I have seen that such internal changes were marked with "chore" in the changelog. That's what I've done here. These chore changes are less interesting for "normal" users.

Please feel free to give me feedback.