### PR TITLE
Update husky and let lint-staged fix ESLint issues

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-[ -f "$(dirname "$0")/_/husky.sh" ] && . "$(dirname "$0")/_/husky.sh"
-
 if command -v npm &> /dev/null; then
   npm run lint:staged
 fi

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 *.js
 .eslintignore
+.husky/pre-commit
 .prettierignore
 /config
 /coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ _This release is scheduled to be released on 2024-04-01._
 
 ### Added
 
-- Output of system information to the console for troubleshooting (#3328 and #3337), ignore errors under aarch64
-- [chore] Add `eslint-plugin-package-json` to lint the `package.json` files
+- Output of system information to the console for troubleshooting (#3328 and #3337), ignore errors under aarch64 (#3349)
+- [chore] Add `eslint-plugin-package-json` to lint the `package.json` files (#3368)
 
 ### Updated
 
@@ -22,6 +22,7 @@ _This release is scheduled to be released on 2024-04-01._
 - Rework logging colors (#3350)
 - Update electron to v28 and update other dependencies (#3357)
 - Update pm2 to v5.3.1 with no allow-ghsas (#3364)
+- [chore] Update husky and let lint-staged fix ESLint issues
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
 				"eslint-plugin-package-json": "^0.10.1",
 				"eslint-plugin-unicorn": "^50.0.1",
 				"express-basic-auth": "^1.2.1",
-				"husky": "^8.0.3",
+				"husky": "^9.0.6",
 				"jest": "^29.7.0",
 				"jsdom": "^23.2.0",
 				"lint-staged": "^15.2.0",
@@ -5852,15 +5852,15 @@
 			}
 		},
 		"node_modules/husky": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-			"integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/husky/-/husky-9.0.6.tgz",
+			"integrity": "sha512-EEuw/rfTiMjOfuL7pGO/i9otg1u36TXxqjIA6D9qxVjd/UXoDOsLor/BSFf5hTK50shwzCU3aVVwdXDp/lp7RA==",
 			"dev": true,
 			"bin": {
-				"husky": "lib/bin.js"
+				"husky": "bin.js"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/typicode"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"lint:js": "eslint . --fix",
 		"lint:css": "stylelint 'css/main.css' 'fonts/*.css' 'modules/default/**/*.css' 'vendor/*.css' --config .stylelintrc.json --fix",
 		"lint:staged": "lint-staged",
-		"prepare": "[ -f node_modules/.bin/husky ] && husky install || echo no husky installed."
+		"prepare": "[ -f node_modules/.bin/husky ] && husky || echo no husky installed."
 	},
 	"repository": "MagicMirrorOrg/MagicMirror",
 	"keywords": [
@@ -53,7 +53,7 @@
 		"eslint-plugin-package-json": "^0.10.1",
 		"eslint-plugin-unicorn": "^50.0.1",
 		"express-basic-auth": "^1.2.1",
-		"husky": "^8.0.3",
+		"husky": "^9.0.6",
 		"jest": "^29.7.0",
 		"jsdom": "^23.2.0",
 		"lint-staged": "^15.2.0",
@@ -88,7 +88,7 @@
 	},
 	"lint-staged": {
 		"*": "prettier --write",
-		"*.js": "eslint",
+		"*.js": "eslint --fix",
 		"*.css": "stylelint"
 	},
 	"_moduleAliases": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 	"lint-staged": {
 		"*": "prettier --write",
 		"*.js": "eslint --fix",
-		"*.css": "stylelint"
+		"*.css": "stylelint --fix"
 	},
 	"_moduleAliases": {
 		"node_helper": "js/node_helper.js",


### PR DESCRIPTION
The new version of husky makes it possible to simplify the pre-commit hook a little.

And since prettier no longer takes care of the JavaScript files in our project, it can no longer come into conflict with ESLint while running lint-staged. Therefore we can activate the correction of ESLint issues here.