### PR TITLE
[calendar] deny fetch interval < 60000 and set 60000 in this case (prevent fetch loop failed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ _This release is scheduled to be released on 2024-04-01._
 - Ignore all custom css files (#3359)
 - [newsfeed] Fix newsfeed stall issue introduced by #3336 (#3361)
 - Changed `log.debug` to `log.log` in `app.js` where logLevel is not set because config is not loaded at this time (#3353)
+- [calandar] deny fetch interval < 60000 and set 60000 in this case (prevent fetch loop failed)
 
 ### Deleted
 

--- a/modules/default/calendar/node_helper.js
+++ b/modules/default/calendar/node_helper.js
@@ -47,9 +47,14 @@ module.exports = NodeHelper.create({
 		}
 
 		let fetcher;
+		let fetchIntervalCorrected;
 		if (typeof this.fetchers[identifier + url] === "undefined") {
-			Log.log(`Create new calendarfetcher for url: ${url} - Interval: ${fetchInterval}`);
-			fetcher = new CalendarFetcher(url, fetchInterval, excludedEvents, maximumEntries, maximumNumberOfDays, auth, broadcastPastEvents, selfSignedCert);
+			if (fetchInterval < 60000) {
+				Log.warn(`fetchInterval for url ${url} must be >= 60000`);
+				fetchIntervalCorrected = 60000;
+			}
+			Log.log(`Create new calendarfetcher for url: ${url} - Interval: ${fetchIntervalCorrected || fetchInterval}`);
+			fetcher = new CalendarFetcher(url, fetchIntervalCorrected || fetchInterval, excludedEvents, maximumEntries, maximumNumberOfDays, auth, broadcastPastEvents, selfSignedCert);
 
 			fetcher.onReceive((fetcher) => {
 				this.broadcastEvents(fetcher, identifier);


### PR DESCRIPTION
Hi, I had the case of some users who set a very small fetchinterval (10 sec for example)
in some cases, it may be that the request did not have time to complete correctly and that the next one has already been sent (generally on start of MM²)
I think that lock min fetchInterval to 60000 is a good idea