### PR TITLE
add error message if config.js appears empty after loading w require() in app.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ _This release is scheduled to be released on 2024-04-01._
 - Ignore all custom css files (#3359)
 - [newsfeed] Fix newsfeed stall issue introduced by #3336 (#3361)
 - Changed `log.debug` to `log.log` in `app.js` where logLevel is not set because config is not loaded at this time (#3353)
+- added message in case where config.js is missing the module.export line PR #3383
 
 ### Deleted
 

--- a/js/app.js
+++ b/js/app.js
@@ -115,8 +115,8 @@ function App () {
 		try {
 			fs.accessSync(configFilename, fs.F_OK);
 			const c = require(configFilename);
-			if( Object.keys(c).length == 0 ) {
-                          Log.error("WARNING! Config file appears empty, maybe missing module.exports last line?");
+			if (Object.keys(c).length === 0) {
+				Log.error("WARNING! Config file appears empty, maybe missing module.exports last line?");
 			}
 			checkDeprecatedOptions(c);
 			return Object.assign(defaults, c);

--- a/js/app.js
+++ b/js/app.js
@@ -115,6 +115,9 @@ function App () {
 		try {
 			fs.accessSync(configFilename, fs.F_OK);
 			const c = require(configFilename);
+			if( Object.keys(c).length == 0 ) {
+                          Log.error("WARNING! Config file appears empty, maybe missing module.exports last line?");
+			}
 			checkDeprecatedOptions(c);
 			return Object.assign(defaults, c);
 		} catch (e) {


### PR DESCRIPTION
from forum, https://forum.magicmirror.builders/topic/18493/node_helper-js-is-not-working
user created own config.js, did not copy the module exports line..

this caused the js/defaults.js list of modules to be processed for node_helpers
but the physical config.js to be loaded for the web page  (hard coded in index.html)

so user modules needing node_helper didn't have that ..

this adds a warning message in npm start output to help user resolve.. took two days to debug without message
