### PR TITLE
add wrapper ClassName // DOM_CONTENT_UPDATED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ _This release is scheduled to be released on 2024-07-01._
 
 ### Added
 
+- wrapper ClassName when using njk
+- `DOM_CONTENT_UPDATED` notification when updateDom() complete
+
 ### Removed
 
 ### Updated

--- a/js/main.js
+++ b/js/main.js
@@ -140,7 +140,10 @@ const MM = (function () {
 				.then(function (newContent) {
 					const updatePromise = updateDomWithContent(module, speed, newHeader, newContent, animateOut, animateIn, createAnimatedDom);
 
-					updatePromise.then(resolve).catch(Log.error);
+					updatePromise
+						.then(resolve)
+						.then(() => module.notificationReceived("DOM_CONTENT_UPDATED", null, null))
+						.catch(Log.error);
 				})
 				.catch(Log.error);
 		});

--- a/js/module.js
+++ b/js/module.js
@@ -76,6 +76,8 @@ const Module = Class.extend({
 	getDom () {
 		return new Promise((resolve) => {
 			const div = document.createElement("div");
+			// set className to njk wrapper
+			div.className = `${this.name}-njk`;
 			const template = this.getTemplate();
 			const templateData = this.getTemplateData();
 


### PR DESCRIPTION
Added:
 * ~~`DOM_CONTENT_UPDATED` notification when a module is updated with `updateDom()`~~ to do better
 * set className for njk wrapper: 
     * There is no class name to the main wrapper of the module and It's dificult to identify it
     * ---> define it to `<module_name>-njk`

Idea:
  Add a callback option in `updateDom()`

```
  if (typeof updateOptions?.options?.callback === "function") {
    updateOptions.options.callback();
    //module.notificationReceived("DOM_CONTENT_UPDATED",null,null))
  }
```

can be used with:
 ```
this.updateDom({options: { speed: 2, callback: () => this.checkInactive()}});
```
