### PR TITLE
Open-Meteo: Fix forecast and hourly weather to use real temperatures, not apparent temperatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,11 @@ Thanks to: @kleinmantara (to be continued before release)
 
 ### Fixed
 
-- Fix crash possibility if `module: <name>` is not defined and on `postion: <positon>` misktake.
+- [core] Fixed crash possibility if `module: <name>` is not defined and on `postion: <positon>` misktake.
 - [weather] Fixed precipitationProbability in forecast for provider openmeteo (#3446)
 - [weather] Fixed type=daily for provider openmeteo having no data when running after 23:00 (#3449)
 - [weather] Fixed type=daily for provider openmeteo showing nightly icons in forecast when current time is "nightly" (#3458)
+- [weather] Fixed forecast and hourly weather for provider openmeteo to use real temperatures, not apparent temperatures
 
 ## [2.27.0] - 2024-04-01
 

--- a/modules/default/weather/providers/openmeteo.js
+++ b/modules/default/weather/providers/openmeteo.js
@@ -398,9 +398,9 @@ WeatherProvider.register("openmeteo", {
 			currentWeather.windFromDirection = weather.winddirection_10m_dominant;
 			currentWeather.sunrise = weather.sunrise;
 			currentWeather.sunset = weather.sunset;
-			currentWeather.temperature = parseFloat((weather.apparent_temperature_max + weather.apparent_temperature_min) / 2);
-			currentWeather.minTemperature = parseFloat(weather.apparent_temperature_min);
-			currentWeather.maxTemperature = parseFloat(weather.apparent_temperature_max);
+			currentWeather.temperature = parseFloat((weather.temperature_2m_max + weather.temperature_2m_min) / 2);
+			currentWeather.minTemperature = parseFloat(weather.temperature_2m_min);
+			currentWeather.maxTemperature = parseFloat(weather.temperature_2m_max);
 			currentWeather.weatherType = this.convertWeatherType(weather.weathercode, currentWeather.isDayTime());
 			currentWeather.rain = parseFloat(weather.rain_sum);
 			currentWeather.snow = parseFloat(weather.snowfall_sum * 10);
@@ -432,9 +432,9 @@ WeatherProvider.register("openmeteo", {
 			currentWeather.windFromDirection = weather.winddirection_10m;
 			currentWeather.sunrise = weathers.daily[h].sunrise;
 			currentWeather.sunset = weathers.daily[h].sunset;
-			currentWeather.temperature = parseFloat(weather.apparent_temperature);
-			currentWeather.minTemperature = parseFloat(weathers.daily[h].apparent_temperature_min);
-			currentWeather.maxTemperature = parseFloat(weathers.daily[h].apparent_temperature_max);
+			currentWeather.temperature = parseFloat(weather.temperature_2m);
+			currentWeather.minTemperature = parseFloat(weathers.daily[h].temperature_2m_min);
+			currentWeather.maxTemperature = parseFloat(weathers.daily[h].temperature_2m_max);
 			currentWeather.weatherType = this.convertWeatherType(weather.weathercode, currentWeather.isDayTime());
 			currentWeather.humidity = parseFloat(weather.relativehumidity_2m);
 			currentWeather.rain = parseFloat(weather.rain);


### PR DESCRIPTION
As discussed in #3466, the Open-Meteo provider is using the apparent temperature ("Feels like") in the forecast and hourly weather reporting.  This is contrary to expected behavior.

Note: I'm a little unclear on how I should be editing the `CHANGELOG.md` file with this PR - happy to update this PR with a little guidance.  This is my first attempted PR in this project.

Let me know if there are any questions.