### PR TITLE
Update compliments.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [2.27.0] - 2024-04-01
 
-Thanks to: @bugsounet, @crazyscot, @illimarkangur, @jkriegshauser, @khassel, @KristjanESPERANTO, @Paranoid93, @rejas, @sdetweil and @vppencilsharpener.
+Thanks to: @bugsounet, @crazyscot, @illimarkangur, @jkriegshauser, @khassel, @KristjanESPERANTO, @Paranoid93, @rejas, @sdetweil, @vppencilsharpener and @WallysWellies.
 
 This release marks the first release without Michael Teeuw (@michmich). A very special thanks to him for creating MagicMirror and leading the project for so many years.
 
@@ -20,6 +20,7 @@ For more info, please read the following post: [A New Chapter for MagicMirror: T
 - [weather] `showHumidity` config is now a string describing where to show this element. Supported values: "wind", "temp", "feelslike", "below", "none". (#3330)
 - electron-rebuild test suite for electron and 3rd party modules compatibility (#3392)
 - Create MM² icon and attach it to electron process (#3407)
+- [compliments] Added `specialDayUnique` config option which defaults to "true", replacing the existing compliments array with only the compliments that have been configured for that day (#3465)
 
 ### Updated
 

--- a/modules/default/compliments/compliments.js
+++ b/modules/default/compliments/compliments.js
@@ -15,7 +15,8 @@ Module.register("compliments", {
 		morningEndTime: 12,
 		afternoonStartTime: 12,
 		afternoonEndTime: 17,
-		random: true
+		random: true,
+        specialDayUnique: true
 	},
 	lastIndexUsed: -1,
 	// Set currentweather from module
@@ -98,6 +99,10 @@ Module.register("compliments", {
 		// Add compliments for special days
 		for (let entry in this.config.compliments) {
 			if (new RegExp(entry).test(date)) {
+                // Only display compliments configured for the day if specialDayUnique set to true
+                if (this.config.specialDayUnique) {
+                    compliments.length = 0;
+                }
 				Array.prototype.push.apply(compliments, this.config.compliments[entry]);
 			}
 		}

--- a/modules/default/compliments/compliments.js
+++ b/modules/default/compliments/compliments.js
@@ -16,7 +16,7 @@ Module.register("compliments", {
 		afternoonStartTime: 12,
 		afternoonEndTime: 17,
 		random: true,
-        specialDayUnique: true
+		specialDayUnique: true
 	},
 	lastIndexUsed: -1,
 	// Set currentweather from module
@@ -99,10 +99,10 @@ Module.register("compliments", {
 		// Add compliments for special days
 		for (let entry in this.config.compliments) {
 			if (new RegExp(entry).test(date)) {
-                // Only display compliments configured for the day if specialDayUnique set to true
-                if (this.config.specialDayUnique) {
-                    compliments.length = 0;
-                }
+				// Only display compliments configured for the day if specialDayUnique set to true
+				if (this.config.specialDayUnique) {
+					compliments.length = 0;
+				}
 				Array.prototype.push.apply(compliments, this.config.compliments[entry]);
 			}
 		}


### PR DESCRIPTION
`Fixes #3465`

Add config option `specialDayUnique` that replaces the compliments array with only the compliments configured for that day. Default setting is `true`. Can be disabled by setting the option to `false` which will add the days compliments to the existing array.