### PR TITLE
Update compliments module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ _This release is scheduled to be released on 2024-07-01._
 
 ### Added
 
+- [compliments] Added `specialDayUnique` config option, defaults to `false`. When set to `true` it replaces the existing compliments array with only the compliments that have been configured for that day (#3465)
+
 ### Removed
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ _This release is scheduled to be released on 2024-07-01._
 
 ### Added
 
-- [compliments] Added `specialDayUnique` config option, defaults to `false`. When set to `true` it replaces the existing compliments array with only the compliments that have been configured for that day (#3465)
+- [compliments] Added `specialDayUnique` config option, defaults to `false`. (#3465)
 
 ### Removed
 

--- a/modules/default/compliments/compliments.js
+++ b/modules/default/compliments/compliments.js
@@ -15,7 +15,8 @@ Module.register("compliments", {
 		morningEndTime: 12,
 		afternoonStartTime: 12,
 		afternoonEndTime: 17,
-		random: true
+		random: true,
+		specialDayUnique: false
 	},
 	lastIndexUsed: -1,
 	// Set currentweather from module
@@ -98,6 +99,10 @@ Module.register("compliments", {
 		// Add compliments for special days
 		for (let entry in this.config.compliments) {
 			if (new RegExp(entry).test(date)) {
+				// Only display compliments configured for the day if specialDayUnique is set to true
+				if (this.config.specialDayUnique) {
+					compliments.length = 0;
+				}
 				Array.prototype.push.apply(compliments, this.config.compliments[entry]);
 			}
 		}

--- a/tests/configs/modules/compliments/compliments_specialDayUnique_false.js
+++ b/tests/configs/modules/compliments/compliments_specialDayUnique_false.js
@@ -4,7 +4,6 @@ let config = {
 			module: "compliments",
 			position: "middle_center",
 			config: {
-				updateInterval: 1000 * 5, // Update every 5 secs
 				specialDayUnique: false,
 				compliments: {
 					anytime: [

--- a/tests/configs/modules/compliments/compliments_specialDayUnique_false.js
+++ b/tests/configs/modules/compliments/compliments_specialDayUnique_false.js
@@ -1,0 +1,25 @@
+let config = {
+    modules: [
+        {
+            module: "compliments",
+            position: "middle_center",
+            config: {
+                updateInterval: 1000 * 5, // Update every 10 secs
+                specialDayUnique: false,
+                compliments: {
+                    anytime: [
+                        "Typical message 1",
+                        "Typical message 2",
+                        "Typical message 3"
+                    ],
+                    "....-..-..": [
+                        "Special day message"
+                    ]
+                },
+            },
+        }
+    ]
+};
+
+/*************** DO NOT EDIT THE LINE BELOW ***************/
+if (typeof module !== "undefined") { module.exports = config; }

--- a/tests/configs/modules/compliments/compliments_specialDayUnique_false.js
+++ b/tests/configs/modules/compliments/compliments_specialDayUnique_false.js
@@ -1,24 +1,22 @@
 let config = {
-    modules: [
-        {
-            module: "compliments",
-            position: "middle_center",
-            config: {
-                updateInterval: 1000 * 5, // Update every 5 secs
-                specialDayUnique: false,
-                compliments: {
-                    anytime: [
-                        "Typical message 1",
-                        "Typical message 2",
-                        "Typical message 3"
-                    ],
-                    "....-..-..": [
-                        "Special day message"
-                    ]
-                },
-            },
-        }
-    ]
+	modules: [
+		{
+			module: "compliments",
+			position: "middle_center",
+			config: {
+				updateInterval: 1000 * 5, // Update every 5 secs
+				specialDayUnique: false,
+				compliments: {
+					anytime: [
+						"Typical message 1",
+						"Typical message 2",
+						"Typical message 3"
+					],
+					"....-..-..": ["Special day message"]
+				}
+			}
+		}
+	]
 };
 
 /*************** DO NOT EDIT THE LINE BELOW ***************/

--- a/tests/configs/modules/compliments/compliments_specialDayUnique_false.js
+++ b/tests/configs/modules/compliments/compliments_specialDayUnique_false.js
@@ -4,7 +4,7 @@ let config = {
             module: "compliments",
             position: "middle_center",
             config: {
-                updateInterval: 1000 * 5, // Update every 10 secs
+                updateInterval: 1000 * 5, // Update every 5 secs
                 specialDayUnique: false,
                 compliments: {
                     anytime: [

--- a/tests/configs/modules/compliments/compliments_specialDayUnique_true.js
+++ b/tests/configs/modules/compliments/compliments_specialDayUnique_true.js
@@ -1,24 +1,22 @@
 let config = {
-    modules: [
-        {
-            module: "compliments",
-            position: "middle_center",
-            config: {
-                updateInterval: 1000 * 5, // Update every 5 secs
-                specialDayUnique: true,
-                compliments: {
-                    anytime: [
-                        "Typical message 1",
-                        "Typical message 2",
-                        "Typical message 3"
-                    ],
-                    "....-..-..": [
-                        "Special day message"
-                    ]
-                },
-            },
-        }
-    ]
+	modules: [
+		{
+			module: "compliments",
+			position: "middle_center",
+			config: {
+				updateInterval: 1000 * 5, // Update every 5 secs
+				specialDayUnique: true,
+				compliments: {
+					anytime: [
+						"Typical message 1",
+						"Typical message 2",
+						"Typical message 3"
+					],
+					"....-..-..": ["Special day message"]
+				}
+			}
+		}
+	]
 };
 
 /*************** DO NOT EDIT THE LINE BELOW ***************/

--- a/tests/configs/modules/compliments/compliments_specialDayUnique_true.js
+++ b/tests/configs/modules/compliments/compliments_specialDayUnique_true.js
@@ -1,0 +1,25 @@
+let config = {
+    modules: [
+        {
+            module: "compliments",
+            position: "middle_center",
+            config: {
+                updateInterval: 1000 * 5, // Update every 10 secs
+                specialDayUnique: true,
+                compliments: {
+                    anytime: [
+                        "Typical message 1",
+                        "Typical message 2",
+                        "Typical message 3"
+                    ],
+                    "....-..-..": [
+                        "Special day message"
+                    ]
+                },
+            },
+        }
+    ]
+};
+
+/*************** DO NOT EDIT THE LINE BELOW ***************/
+if (typeof module !== "undefined") { module.exports = config; }

--- a/tests/configs/modules/compliments/compliments_specialDayUnique_true.js
+++ b/tests/configs/modules/compliments/compliments_specialDayUnique_true.js
@@ -4,7 +4,7 @@ let config = {
             module: "compliments",
             position: "middle_center",
             config: {
-                updateInterval: 1000 * 5, // Update every 10 secs
+                updateInterval: 1000 * 5, // Update every 5 secs
                 specialDayUnique: true,
                 compliments: {
                     anytime: [

--- a/tests/configs/modules/compliments/compliments_specialDayUnique_true.js
+++ b/tests/configs/modules/compliments/compliments_specialDayUnique_true.js
@@ -4,7 +4,6 @@ let config = {
 			module: "compliments",
 			position: "middle_center",
 			config: {
-				updateInterval: 1000 * 5, // Update every 5 secs
 				specialDayUnique: true,
 				compliments: {
 					anytime: [

--- a/tests/e2e/modules/compliments_spec.js
+++ b/tests/e2e/modules/compliments_spec.js
@@ -54,4 +54,28 @@ describe("Compliments module", () => {
 			await expect(doTest(["Remote compliment file works!"])).resolves.toBe(true);
 		});
 	});
+
+	describe("Feature specialDayUnique in compliments module", () => {
+		describe("specialDayUnique is false", () => {
+			beforeAll(async () => {
+				await helpers.startApplication("tests/configs/modules/compliments/compliments_specialDayUnique_false.js");
+				await helpers.getDocument();
+			});
+
+			it("compliments array can contain all values", async () => {
+				await expect(doTest(["Special day message", "Typical message 1", "Typical message 2", "Typical message 3"])).resolves.toBe(true);
+			});
+		});
+
+		describe("specialDayUnique is true", () => {
+			beforeAll(async () => {
+				await helpers.startApplication("tests/configs/modules/compliments/compliments_specialDayUnique_true.js");
+				await helpers.getDocument();
+			});
+
+			it("compliments array contains only special value", async () => {
+				await expect(doTest(["Special day message"])).resolves.toBe(true);
+			});
+		});
+	});
 });


### PR DESCRIPTION
`Fixes #3465`

Add config option `specialDayUnique` that defaults to `false` and causes special day compliments to be added to the existing compliments array. Setting this option to `true` will only show the compliments that have been configured for that day.