### PR TITLE
Use latest@version of node for automated-tests.yaml

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          check-latest: true
           cache: "npm"
       - name: "Install dependencies"
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Thanks to: @kleinmantara (to be continued before release)
 - [core] Update dependencies including electron to v31
 - [core] use node >= v20
 - [core] Update `config.js.sample` to use openmeteo as weather provider which needs no api key
+- [Tests] Use latest@version of node for automated-tests.yaml
 
 ### Fixed
 


### PR DESCRIPTION
Maybe it's a good idea to use latest@node version for automated-tests

Actually it's an "random" version

Note: it's already used [there in electronRebuild](https://github.com/MagicMirrorOrg/MagicMirror/blob/develop/.github/workflows/electronRebuild.yaml#L19)