### PR TITLE
updatenotification: avoid using pm2 when running in docker container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 _This release is scheduled to be released on 2024-07-01._
 
-Thanks to: @btoconnor, @bugsounet, @khassel, @kleinmantara and @WallysWellies.
+Thanks to: @btoconnor, @bugsounet, @JasonStieber, @khassel, @kleinmantara and @WallysWellies.
 
 > ⚠️ This release needs nodejs version >= v20
 
@@ -29,6 +29,7 @@ Thanks to: @btoconnor, @bugsounet, @khassel, @kleinmantara and @WallysWellies.
 - [core] use node >= v20 (#3462)
 - [core] Update `config.js.sample` to use openmeteo as weather provider which needs no api key
 - [tests] Use latest@version of node for `automated-tests.yaml` (#3483)
+- [updatenotification] Avoid using pm2 when running in docker container
 
 ### Fixed
 

--- a/modules/default/updatenotification/update_helper.js
+++ b/modules/default/updatenotification/update_helper.js
@@ -1,6 +1,6 @@
 const Exec = require("node:child_process").exec;
 const Spawn = require("node:child_process").spawn;
-const pm2 = require("pm2");
+const fs = require("node:fs");
 
 const Log = require("logger");
 
@@ -139,6 +139,7 @@ class Updater {
 	// restart MagicMiror with "pm2"
 	pm2Restart () {
 		Log.info("updatenotification: PM2 will restarting MagicMirror...");
+		const pm2 = require("pm2");
 		pm2.restart(this.PM2, (err, proc) => {
 			if (err) {
 				Log.error("updatenotification:[PM2] restart Error", err);
@@ -160,6 +161,14 @@ class Updater {
 	check_PM2_Process () {
 		Log.info("updatenotification: Checking PM2 using...");
 		return new Promise((resolve) => {
+			if (fs.existsSync("/.dockerenv")) {
+				Log.info("updatenotification: Running in docker container, not using PM2 ...");
+				this.usePM2 = false;
+				resolve(false);
+				return;
+			}
+
+			const pm2 = require("pm2");
 			pm2.connect((err) => {
 				if (err) {
 					Log.error("updatenotification: [PM2]", err);


### PR DESCRIPTION
related to #3480 

Change module updatenotification so that it can work without `pm2` in a docker container.

It now tests if file `/.dockerenv` exists and if so `require("pm2")` is never called.