### PR TITLE
fixes e2e tests running in docker container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Thanks to: @kleinmantara (to be continued before release)
 - [weather] Fixed type=daily for provider openmeteo having no data when running after 23:00 (#3449)
 - [weather] Fixed type=daily for provider openmeteo showing nightly icons in forecast when current time is "nightly" (#3458)
 - [weather] Fixed forecast and hourly weather for provider openmeteo to use real temperatures, not apparent temperatures
+- [tests] Fixed e2e tests running in docker container which needs `address: "0.0.0.0"` (#3479)
 
 ## [2.27.0] - 2024-04-01
 

--- a/js/app.js
+++ b/js/app.js
@@ -58,6 +58,10 @@ function App () {
 	async function loadConfig () {
 		Log.log("Loading config ...");
 		const defaults = require(`${__dirname}/defaults`);
+		if (process.env.JEST_WORKER_ID !== undefined) {
+			// if we are running with jest
+			defaults.address = "0.0.0.0";
+		}
 
 		// For this check proposed to TestSuite
 		// https://forum.magicmirror.builders/topic/1456/test-suite-for-magicmirror/8


### PR DESCRIPTION
which needs `address: "0.0.0.0"`

fixes #3479 