### PR TITLE
version 2.5 has been deprecated, changing default to 3.0

### DIFF
--- a/modules/default/weather/providers/openweathermap.js
+++ b/modules/default/weather/providers/openweathermap.js
@@ -11,7 +11,7 @@ WeatherProvider.register("openweathermap", {
 
 	// Set the default config properties that is specific to this provider
 	defaults: {
-		apiVersion: "2.5",
+		apiVersion: "3.0",
 		apiBase: "https://api.openweathermap.org/data/",
 		weatherEndpoint: "", // can be "onecall", "forecast" or "weather" (for current)
 		locationID: false,


### PR DESCRIPTION
I'm new to using GitHub as a collaborative platform so I'm very new to all of this, let me know if I goofed something and how I can do it better next time!

OpenWeather's One Call API has deprecated version 2.5 so it won't anymore. I changed the default value of apiVersion from 2.5 to 3.0 so newbies like me will have an easier time figuring it out!
