### PR TITLE
Fixes the UK Met Office Datahub provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ _This release is scheduled to be released on 2024-10-01._
 ### Fixed
 
 - Fixed `checks` badge in README.md
+- [weather] Fixed issue with the UK Met Office provider following a change in their API paths and header info.
 
 ## [2.28.0] - 2024-07-01
 

--- a/modules/default/weather/providers/ukmetofficedatahub.js
+++ b/modules/default/weather/providers/ukmetofficedatahub.js
@@ -60,7 +60,7 @@ WeatherProvider.register("ukmetofficedatahub", {
 	getHeaders () {
 		return {
 			accept: "application/json",
-			apikey: this.config.apiKey,
+			apikey: this.config.apiKey
 		};
 	},
 

--- a/modules/default/weather/providers/ukmetofficedatahub.js
+++ b/modules/default/weather/providers/ukmetofficedatahub.js
@@ -11,9 +11,8 @@
  * This provider requires longitude/latitude coordinates, rather than a location ID (as with the previous Met Office provider)
  * Provide the following in your config.js file:
  * 		weatherProvider: "ukmetofficedatahub",
- * 		apiBase: "https://api-metoffice.apiconnect.ibmcloud.com/metoffice/production/v0/forecasts/point/",
+ * 		apiBase: "https://data.hub.api.metoffice.gov.uk/sitespecific/v0/point/",
  * 		apiKey: "[YOUR API KEY]",
- * 		apiSecret: "[YOUR API SECRET]",
  * 		lat: [LATITUDE (DECIMAL)],
  * 		lon: [LONGITUDE (DECIMAL)]
  *
@@ -38,14 +37,13 @@ WeatherProvider.register("ukmetofficedatahub", {
 
 	// Set the default config properties that is specific to this provider
 	defaults: {
-		apiBase: "https://api-metoffice.apiconnect.ibmcloud.com/metoffice/production/v0/forecasts/point/",
+		apiBase: "https://data.hub.api.metoffice.gov.uk/sitespecific/v0/point/",
 		apiKey: "",
-		apiSecret: "",
 		lat: 0,
 		lon: 0
 	},
 
-	// Build URL with query strings according to DataHub API (https://metoffice.apiconnect.ibmcloud.com/metoffice/production/api)
+	// Build URL with query strings according to DataHub API (https://datahub.metoffice.gov.uk/docs/f/category/site-specific/type/site-specific/api-documentation#get-/point/hourly)
 	getUrl (forecastType) {
 		let queryStrings = "?";
 		queryStrings += `latitude=${this.config.lat}`;
@@ -58,12 +56,11 @@ WeatherProvider.register("ukmetofficedatahub", {
 
 	// Build the list of headers for the request
 	// For DataHub requests, the API key/secret are sent in the headers rather than as query strings.
-	// Headers defined according to Data Hub API (https://metoffice.apiconnect.ibmcloud.com/metoffice/production/api)
+	// Headers defined according to Data Hub API (https://datahub.metoffice.gov.uk/docs/f/category/site-specific/type/site-specific/api-documentation#get-/point/hourly)
 	getHeaders () {
 		return {
 			accept: "application/json",
-			"x-ibm-client-id": this.config.apiKey,
-			"x-ibm-client-secret": this.config.apiSecret
+			apikey: this.config.apiKey,
 		};
 	},
 


### PR DESCRIPTION
Fixes #3384

Changed the UKMetOfficeDataHub provider to the new API structure as per the documentation.

API Base URL updated.
Header information amended to the correct key name.
API Secret no longer required so removed.

Changelog updated to reflect the change.

