### PR TITLE
allow custom module positions by setting `allowCustomModulePositions`…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ _This release is scheduled to be released on 2024-10-01._
 
 ### Updated
 
-- [weather] Updated `apiVersion` default from 2.5 to 3.0
+- [weather] Updated `apiVersion` default from 2.5 to 3.0 (#3424)
 - [core] Updated dependencies
+- [core] Allow custom module positions by setting `allowCustomModulePositions` in `config.js` (fixes #3504, related to https://github.com/MagicMirrorOrg/MagicMirror/pull/3445)
 
 ### Fixed
 

--- a/js/defaults.js
+++ b/js/defaults.js
@@ -27,6 +27,7 @@ const defaults = {
 	// (interval 30 seconds). If startup-timestamp has changed the client reloads the magicmirror webpage.
 	checkServerInterval: 30 * 1000,
 	reloadAfterServerRestart: false,
+	allowCustomModulePositions: false,
 
 	modules: [
 		{

--- a/js/loader.js
+++ b/js/loader.js
@@ -50,7 +50,7 @@ const Loader = (function () {
 	 * @returns {object[]} module data as configured in config
 	 */
 	const getAllModules = function () {
-		const AllModules = config.modules.filter((module) => (module.module !== undefined) && (MM.getAvailableModulePositions.indexOf(module.position) > -1 || typeof (module.position) === "undefined"));
+		const AllModules = config.modules.filter((module) => (module.module !== undefined) && (MM.getAvailableModulePositions.indexOf(module.position) > -1 || typeof (module.position) === "undefined" || config.allowCustomModulePositions));
 		return AllModules;
 	};
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -34,6 +34,7 @@ module.exports = {
 
 	// return if postion is on modulePositions Array (true/false)
 	moduleHasValidPosition (position) {
+		if (config.allowCustomModulePositions) return true;
 		if (this.getAvailableModulePositions().indexOf(position) === -1) return false;
 		return true;
 	}


### PR DESCRIPTION
… in `config.js`

fixes #3504, related to https://github.com/MagicMirrorOrg/MagicMirror/pull/3445
