### PR TITLE
Fix loading of multiple instances of node_helper when multiple instances of a module are in config.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ _This release is scheduled to be released on 2024-10-01._
 
 ### Fixed
 
+[core] add check for node_helper loading for multiple instances of same module (#3502)
+
 ## [2.28.0] - 2024-07-01
 
 Thanks to: @btoconnor, @bugsounet, @JasonStieber, @khassel, @kleinmantara and @WallysWellies.

--- a/js/app.js
+++ b/js/app.js
@@ -9,6 +9,7 @@ const Log = require("logger");
 const Server = require(`${__dirname}/server`);
 const Utils = require(`${__dirname}/utils`);
 const defaultModules = require(`${__dirname}/../modules/default/defaultmodules`);
+const helperhash = {};
 
 // Get version number.
 global.version = require(`${__dirname}/../package.json`).version;
@@ -175,14 +176,23 @@ function App () {
 
 		const helperPath = `${moduleFolder}/node_helper.js`;
 
-		let loadHelper = true;
-		try {
-			fs.accessSync(helperPath, fs.R_OK);
-		} catch (e) {
-			loadHelper = false;
-			Log.log(`No helper found for module: ${moduleName}.`);
-		}
+		// find out if helper was loaded before for this module
+		// only lload it once
+		let loadHelper = helperhash[moduleName] ? false : true;
 
+		// if this is the 1st time for this module, check for helper file
+		// otherwise, its already loaded, if found
+		if (loadHelper) {
+			try {
+				fs.accessSync(helperPath, fs.R_OK);
+				// indicte we found one to load for this module
+				helperhash[moduleName] = true;
+			} catch (e) {
+				loadHelper = false;
+				Log.log(`No helper found for module: ${moduleName}.`);
+			}
+		}
+		// if the helper was found, AND needed 1st time
 		if (loadHelper) {
 			const Module = require(helperPath);
 			let m = new Module();

--- a/js/app.js
+++ b/js/app.js
@@ -177,7 +177,7 @@ function App () {
 		const helperPath = `${moduleFolder}/node_helper.js`;
 
 		// find out if helper was loaded before for this module
-		// only lload it once
+		// only load it once
 		let loadHelper = helperhash[moduleName] ? false : true;
 
 		// if this is the 1st time for this module, check for helper file


### PR DESCRIPTION
adds a check for already loaded/loading for node helper of a each module, only does once

fixes #3502 


