### PR TITLE
Bug in Weather Units for Broadcasted Notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ _This release is scheduled to be released on 2024-10-01._
 
 - Fixed `checks` badge in README.md
 - [weather] Fixed issue with the UK Met Office provider following a change in their API paths and header info.
+- [weather] Fixed issue for respecting unit config on broadcasted notifications
 
 ## [2.28.0] - 2024-07-01
 

--- a/modules/default/weather/weather.js
+++ b/modules/default/weather/weather.js
@@ -183,9 +183,6 @@ Module.register("weather", {
 			providerName: this.weatherProvider.providerName
 		};
 
-
-		console.log(notificationPayload);
-
 		this.sendNotification("WEATHER_UPDATED", notificationPayload);
 	},
 

--- a/modules/default/weather/weather.js
+++ b/modules/default/weather/weather.js
@@ -170,12 +170,22 @@ Module.register("weather", {
 		}
 
 		const notificationPayload = {
-			currentWeather: this.weatherProvider?.currentWeatherObject?.simpleClone() ?? null,
-			forecastArray: this.weatherProvider?.weatherForecastArray?.map((ar) => ar.simpleClone()) ?? [],
-			hourlyArray: this.weatherProvider?.weatherHourlyArray?.map((ar) => ar.simpleClone()) ?? [],
+			currentWeather: this.config.units === 'imperial' 
+				? WeatherUtils.convertWeatherObjectToImperial(this.weatherProvider?.currentWeatherObject?.simpleClone()) ?? null 
+				: this.weatherProvider?.currentWeatherObject?.simpleClone() ?? null,
+			forecastArray: this.config.units === 'imperial' 
+				? this.weatherProvider?.weatherForecastArray?.map((ar) => WeatherUtils.convertWeatherObjectToImperial(ar.simpleClone())) ?? []
+				: this.weatherProvider?.weatherForecastArray?.map((ar) => ar.simpleClone()) ?? [],
+			hourlyArray:  this.config.units === 'imperial' 
+				? this.weatherProvider?.weatherHourlyArray?.map((ar) => WeatherUtils.convertWeatherObjectToImperial(ar.simpleClone())) ?? []
+				: this.weatherProvider?.weatherHourlyArray?.map((ar) => ar.simpleClone()) ?? [],
 			locationName: this.weatherProvider?.fetchedLocationName,
 			providerName: this.weatherProvider.providerName
 		};
+
+
+		console.log(notificationPayload);
+
 		this.sendNotification("WEATHER_UPDATED", notificationPayload);
 	},
 

--- a/modules/default/weather/weather.js
+++ b/modules/default/weather/weather.js
@@ -170,13 +170,13 @@ Module.register("weather", {
 		}
 
 		const notificationPayload = {
-			currentWeather: this.config.units === 'imperial' 
-				? WeatherUtils.convertWeatherObjectToImperial(this.weatherProvider?.currentWeatherObject?.simpleClone()) ?? null 
+			currentWeather: this.config.units === "imperial"
+				? WeatherUtils.convertWeatherObjectToImperial(this.weatherProvider?.currentWeatherObject?.simpleClone()) ?? null
 				: this.weatherProvider?.currentWeatherObject?.simpleClone() ?? null,
-			forecastArray: this.config.units === 'imperial' 
+			forecastArray: this.config.units === "imperial"
 				? this.weatherProvider?.weatherForecastArray?.map((ar) => WeatherUtils.convertWeatherObjectToImperial(ar.simpleClone())) ?? []
 				: this.weatherProvider?.weatherForecastArray?.map((ar) => ar.simpleClone()) ?? [],
-			hourlyArray:  this.config.units === 'imperial' 
+			hourlyArray: this.config.units === "imperial"
 				? this.weatherProvider?.weatherHourlyArray?.map((ar) => WeatherUtils.convertWeatherObjectToImperial(ar.simpleClone())) ?? []
 				: this.weatherProvider?.weatherHourlyArray?.map((ar) => ar.simpleClone()) ?? [],
 			locationName: this.weatherProvider?.fetchedLocationName,

--- a/modules/default/weather/weatherutils.js
+++ b/modules/default/weather/weatherutils.js
@@ -44,7 +44,7 @@ const WeatherUtils = {
 	 * Convert temp (from degrees C) into imperial or metric unit depending on
 	 * your config
 	 * @param {number} tempInC the temperature in celsius you want to convert
-	 * @param {string} unit can be "imperial" or 'metric'
+	 * @param {string} unit can be 'imperial' or 'metric'
 	 * @returns {number} the converted temperature
 	 */
 	convertTemp (tempInC, unit) {
@@ -54,7 +54,7 @@ const WeatherUtils = {
 	/**
 	 * Convert wind speed into another unit.
 	 * @param {number} windInMS the windspeed in meter/sec you want to convert
-	 * @param {string} unit can be 'beaufort', 'kmh', 'knots, "imperial" (mph)
+	 * @param {string} unit can be 'beaufort', 'kmh', 'knots, 'imperial' (mph)
 	 * or 'metric' (mps)
 	 * @returns {number} the converted windspeed
 	 */

--- a/modules/default/weather/weatherutils.js
+++ b/modules/default/weather/weatherutils.js
@@ -148,7 +148,6 @@ const WeatherUtils = {
 	 * @returns {object} the weather object with converted values to imperial
 	 */
 	convertWeatherObjectToImperial (weatherObject) {
-		console.log("edo");
 		if (!weatherObject || Object.keys(weatherObject).length === 0) return null;
 
 		let imperialWeatherObject = { ...weatherObject };

--- a/modules/default/weather/weatherutils.js
+++ b/modules/default/weather/weatherutils.js
@@ -131,6 +131,21 @@ const WeatherUtils = {
 		return ((feelsLike - 32) * 5) / 9;
 	},
 
+	/**
+	 * Convert precipitation value into inch
+	 * @param {number} value the precipitation value for convert
+	 * @param {string} valueUnit can be 'mm' or 'cm'
+	 * @returns {number} the converted precipitation value
+	 */
+	convertPrecipitationToInch(value, valueUnit) {
+		if (valueUnit && valueUnit.toLowerCase() === "cm") return value * 0.3937007874;
+		else return value * 0.03937007874;	},
+
+		/**
+	 * Converts the Weather Object's values into imperial unit
+	 * @param {WeatherObject} weatherObject the weather object
+	 * @returns {WeatherObject} the weather object with converted values to imperial
+	 */	
 	convertWeatherObjectToImperial(weatherObject) {
 		if (!weatherObject || Object.keys(weatherObject).length === 0) return null;
 		
@@ -140,10 +155,9 @@ const WeatherUtils = {
 			if (imperialWeatherObject.feelsLikeTemp) imperialWeatherObject.feelsLikeTemp = this.convertTemp(imperialWeatherObject.feelsLikeTemp, 'imperial');
 			if (imperialWeatherObject.maxTemperature) imperialWeatherObject.maxTemperature = this.convertTemp(imperialWeatherObject.maxTemperature, 'imperial');
 			if (imperialWeatherObject.minTemperature) imperialWeatherObject.minTemperature = this.convertTemp(imperialWeatherObject.minTemperature, 'imperial');
-			if (imperialWeatherObject.precipitationAmount) imperialWeatherObject.precipitationAmount = this.convertPrecipitationUnit(imperialWeatherObject.precipitationAmount, 'imperial');
+			if (imperialWeatherObject.precipitationAmount) imperialWeatherObject.precipitationAmount = this.convertPerticipationToInch(imperialWeatherObject.precipitationAmount, 'imperial', imperialWeatherObject.precipitationUnits);
 			if (imperialWeatherObject.temperature) imperialWeatherObject.temperature = this.convertTemp(imperialWeatherObject.temperature, 'imperial');
 			if (imperialWeatherObject.windSpeed) imperialWeatherObject.windSpeed = this.convertWind(imperialWeatherObject.windSpeed, 'imperial');
-			// TODO add if section and method for precipitationAmount convert
 		}
 
 		return imperialWeatherObject;

--- a/modules/default/weather/weatherutils.js
+++ b/modules/default/weather/weatherutils.js
@@ -156,7 +156,7 @@ const WeatherUtils = {
 			if (imperialWeatherObject.feelsLikeTemp) imperialWeatherObject.feelsLikeTemp = this.convertTemp(imperialWeatherObject.feelsLikeTemp, "imperial");
 			if (imperialWeatherObject.maxTemperature) imperialWeatherObject.maxTemperature = this.convertTemp(imperialWeatherObject.maxTemperature, "imperial");
 			if (imperialWeatherObject.minTemperature) imperialWeatherObject.minTemperature = this.convertTemp(imperialWeatherObject.minTemperature, "imperial");
-			if (imperialWeatherObject.precipitationAmount) imperialWeatherObject.precipitationAmount = this.convertPrecipitationToInch(imperialWeatherObject.precipitationAmount, "imperial", imperialWeatherObject.precipitationUnits);
+			if (imperialWeatherObject.precipitationAmount) imperialWeatherObject.precipitationAmount = this.convertPrecipitationToInch(imperialWeatherObject.precipitationAmount, imperialWeatherObject.precipitationUnits);
 			if (imperialWeatherObject.temperature) imperialWeatherObject.temperature = this.convertTemp(imperialWeatherObject.temperature, "imperial");
 			if (imperialWeatherObject.windSpeed) imperialWeatherObject.windSpeed = this.convertWind(imperialWeatherObject.windSpeed, "imperial");
 		}

--- a/modules/default/weather/weatherutils.js
+++ b/modules/default/weather/weatherutils.js
@@ -1,6 +1,3 @@
-const WeatherObject = require("./weatherobject");
-
-
 const WeatherUtils = {
 
 	/**
@@ -147,8 +144,8 @@ const WeatherUtils = {
 
 	/**
 	 * Converts the Weather Object's values into imperial unit
-	 * @param {WeatherObject} weatherObject the weather object
-	 * @returns {WeatherObject} the weather object with converted values to imperial
+	 * @param {object} weatherObject the weather object
+	 * @returns {object} the weather object with converted values to imperial
 	 */
 	convertWeatherObjectToImperial (weatherObject) {
 		if (!weatherObject || Object.keys(weatherObject).length === 0) return null;

--- a/modules/default/weather/weatherutils.js
+++ b/modules/default/weather/weatherutils.js
@@ -148,6 +148,7 @@ const WeatherUtils = {
 	 * @returns {object} the weather object with converted values to imperial
 	 */
 	convertWeatherObjectToImperial (weatherObject) {
+		console.log("edo");
 		if (!weatherObject || Object.keys(weatherObject).length === 0) return null;
 
 		let imperialWeatherObject = { ...weatherObject };
@@ -156,7 +157,7 @@ const WeatherUtils = {
 			if (imperialWeatherObject.feelsLikeTemp) imperialWeatherObject.feelsLikeTemp = this.convertTemp(imperialWeatherObject.feelsLikeTemp, "imperial");
 			if (imperialWeatherObject.maxTemperature) imperialWeatherObject.maxTemperature = this.convertTemp(imperialWeatherObject.maxTemperature, "imperial");
 			if (imperialWeatherObject.minTemperature) imperialWeatherObject.minTemperature = this.convertTemp(imperialWeatherObject.minTemperature, "imperial");
-			if (imperialWeatherObject.precipitationAmount) imperialWeatherObject.precipitationAmount = this.convertPerticipationToInch(imperialWeatherObject.precipitationAmount, "imperial", imperialWeatherObject.precipitationUnits);
+			if (imperialWeatherObject.precipitationAmount) imperialWeatherObject.precipitationAmount = this.convertPrecipitationToInch(imperialWeatherObject.precipitationAmount, "imperial", imperialWeatherObject.precipitationUnits);
 			if (imperialWeatherObject.temperature) imperialWeatherObject.temperature = this.convertTemp(imperialWeatherObject.temperature, "imperial");
 			if (imperialWeatherObject.windSpeed) imperialWeatherObject.windSpeed = this.convertWind(imperialWeatherObject.windSpeed, "imperial");
 		}

--- a/modules/default/weather/weatherutils.js
+++ b/modules/default/weather/weatherutils.js
@@ -129,6 +129,24 @@ const WeatherUtils = {
 		}
 
 		return ((feelsLike - 32) * 5) / 9;
+	},
+
+	convertWeatherObjectToImperial(weatherObject) {
+		if (!weatherObject || Object.keys(weatherObject).length === 0) return null;
+		
+		let imperialWeatherObject = {...weatherObject};
+
+		if (imperialWeatherObject) {
+			if (imperialWeatherObject.feelsLikeTemp) imperialWeatherObject.feelsLikeTemp = this.convertTemp(imperialWeatherObject.feelsLikeTemp, 'imperial');
+			if (imperialWeatherObject.maxTemperature) imperialWeatherObject.maxTemperature = this.convertTemp(imperialWeatherObject.maxTemperature, 'imperial');
+			if (imperialWeatherObject.minTemperature) imperialWeatherObject.minTemperature = this.convertTemp(imperialWeatherObject.minTemperature, 'imperial');
+			if (imperialWeatherObject.precipitationAmount) imperialWeatherObject.precipitationAmount = this.convertPrecipitationUnit(imperialWeatherObject.precipitationAmount, 'imperial');
+			if (imperialWeatherObject.temperature) imperialWeatherObject.temperature = this.convertTemp(imperialWeatherObject.temperature, 'imperial');
+			if (imperialWeatherObject.windSpeed) imperialWeatherObject.windSpeed = this.convertWind(imperialWeatherObject.windSpeed, 'imperial');
+			// TODO add if section and method for precipitationAmount convert
+		}
+
+		return imperialWeatherObject;
 	}
 };
 

--- a/modules/default/weather/weatherutils.js
+++ b/modules/default/weather/weatherutils.js
@@ -30,14 +30,24 @@ const WeatherUtils = {
 		let convertedValue = value;
 		let conversionUnit = valueUnit;
 		if (outputUnit === "imperial") {
-			if (valueUnit && valueUnit.toLowerCase() === "cm") convertedValue = convertedValue * 0.3937007874;
-			else convertedValue = convertedValue * 0.03937007874;
+			convertedValue = this.convertPrecipitationToInch(value, valueUnit);
 			conversionUnit = "in";
 		} else {
 			conversionUnit = valueUnit ? valueUnit : "mm";
 		}
 
 		return `${convertedValue.toFixed(2)} ${conversionUnit}`;
+	},
+
+	/**
+	 * Convert precipitation value into inch
+	 * @param {number} value the precipitation value for convert
+	 * @param {string} valueUnit can be 'mm' or 'cm'
+	 * @returns {number} the converted precipitation value
+	 */
+	convertPrecipitationToInch (value, valueUnit) {
+		if (valueUnit && valueUnit.toLowerCase() === "cm") return value * 0.3937007874;
+		else return value * 0.03937007874;
 	},
 
 	/**
@@ -129,17 +139,6 @@ const WeatherUtils = {
 		}
 
 		return ((feelsLike - 32) * 5) / 9;
-	},
-
-	/**
-	 * Convert precipitation value into inch
-	 * @param {number} value the precipitation value for convert
-	 * @param {string} valueUnit can be 'mm' or 'cm'
-	 * @returns {number} the converted precipitation value
-	 */
-	convertPrecipitationToInch (value, valueUnit) {
-		if (valueUnit && valueUnit.toLowerCase() === "cm") return value * 0.3937007874;
-		else return value * 0.03937007874;
 	},
 
 	/**

--- a/modules/default/weather/weatherutils.js
+++ b/modules/default/weather/weatherutils.js
@@ -1,3 +1,6 @@
+const WeatherObject = require("./weatherobject");
+
+
 const WeatherUtils = {
 
 	/**
@@ -44,7 +47,7 @@ const WeatherUtils = {
 	 * Convert temp (from degrees C) into imperial or metric unit depending on
 	 * your config
 	 * @param {number} tempInC the temperature in celsius you want to convert
-	 * @param {string} unit can be 'imperial' or 'metric'
+	 * @param {string} unit can be "imperial" or 'metric'
 	 * @returns {number} the converted temperature
 	 */
 	convertTemp (tempInC, unit) {
@@ -54,7 +57,7 @@ const WeatherUtils = {
 	/**
 	 * Convert wind speed into another unit.
 	 * @param {number} windInMS the windspeed in meter/sec you want to convert
-	 * @param {string} unit can be 'beaufort', 'kmh', 'knots, 'imperial' (mph)
+	 * @param {string} unit can be 'beaufort', 'kmh', 'knots, "imperial" (mph)
 	 * or 'metric' (mps)
 	 * @returns {number} the converted windspeed
 	 */
@@ -137,27 +140,28 @@ const WeatherUtils = {
 	 * @param {string} valueUnit can be 'mm' or 'cm'
 	 * @returns {number} the converted precipitation value
 	 */
-	convertPrecipitationToInch(value, valueUnit) {
+	convertPrecipitationToInch (value, valueUnit) {
 		if (valueUnit && valueUnit.toLowerCase() === "cm") return value * 0.3937007874;
-		else return value * 0.03937007874;	},
+		else return value * 0.03937007874;
+	},
 
-		/**
+	/**
 	 * Converts the Weather Object's values into imperial unit
 	 * @param {WeatherObject} weatherObject the weather object
 	 * @returns {WeatherObject} the weather object with converted values to imperial
-	 */	
-	convertWeatherObjectToImperial(weatherObject) {
+	 */
+	convertWeatherObjectToImperial (weatherObject) {
 		if (!weatherObject || Object.keys(weatherObject).length === 0) return null;
-		
-		let imperialWeatherObject = {...weatherObject};
+
+		let imperialWeatherObject = { ...weatherObject };
 
 		if (imperialWeatherObject) {
-			if (imperialWeatherObject.feelsLikeTemp) imperialWeatherObject.feelsLikeTemp = this.convertTemp(imperialWeatherObject.feelsLikeTemp, 'imperial');
-			if (imperialWeatherObject.maxTemperature) imperialWeatherObject.maxTemperature = this.convertTemp(imperialWeatherObject.maxTemperature, 'imperial');
-			if (imperialWeatherObject.minTemperature) imperialWeatherObject.minTemperature = this.convertTemp(imperialWeatherObject.minTemperature, 'imperial');
-			if (imperialWeatherObject.precipitationAmount) imperialWeatherObject.precipitationAmount = this.convertPerticipationToInch(imperialWeatherObject.precipitationAmount, 'imperial', imperialWeatherObject.precipitationUnits);
-			if (imperialWeatherObject.temperature) imperialWeatherObject.temperature = this.convertTemp(imperialWeatherObject.temperature, 'imperial');
-			if (imperialWeatherObject.windSpeed) imperialWeatherObject.windSpeed = this.convertWind(imperialWeatherObject.windSpeed, 'imperial');
+			if (imperialWeatherObject.feelsLikeTemp) imperialWeatherObject.feelsLikeTemp = this.convertTemp(imperialWeatherObject.feelsLikeTemp, "imperial");
+			if (imperialWeatherObject.maxTemperature) imperialWeatherObject.maxTemperature = this.convertTemp(imperialWeatherObject.maxTemperature, "imperial");
+			if (imperialWeatherObject.minTemperature) imperialWeatherObject.minTemperature = this.convertTemp(imperialWeatherObject.minTemperature, "imperial");
+			if (imperialWeatherObject.precipitationAmount) imperialWeatherObject.precipitationAmount = this.convertPerticipationToInch(imperialWeatherObject.precipitationAmount, "imperial", imperialWeatherObject.precipitationUnits);
+			if (imperialWeatherObject.temperature) imperialWeatherObject.temperature = this.convertTemp(imperialWeatherObject.temperature, "imperial");
+			if (imperialWeatherObject.windSpeed) imperialWeatherObject.windSpeed = this.convertWind(imperialWeatherObject.windSpeed, "imperial");
 		}
 
 		return imperialWeatherObject;


### PR DESCRIPTION
This PR resolve Issue number #3419 .

I have added the method `convertWeatherObjectToImperial()` which converts the units of the `notificationPayload` to imperial if needed, in order to pass the object in `sendNotification()`.
