### PR TITLE
Updated to new notification name `DOM_OBJECTS_UPDATED` -> `MODULE_DOM_UPDATED`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ _This release is scheduled to be released on 2024-10-01._
 - [core] Add spelling check (cspell): `npm run test:spelling` and handle spelling issues (#3544)
 - [core] removed `config.paths.vendor` (could not work because `vendor` is hardcoded in `index.html`), renamed `config.paths.modules` to `config.foreignModulesDir`, added variable `MM_CUSTOMCSS_FILE` which - if set - overrides `config.customCss`, added variable `MM_MODULES_DIR` which - if set - overrides `config.foreignModulesDir` (#3530)
 - [core] elements are now removed from `index.html` when loading script or stylesheet files fails
-- [core] Added `DOM_OBJECTS_UPDATED` notification each time the DOM is re-rendered via `updateDom` (#3534)
+- [core] Added `MODULE_DOM_UPDATED` notification each time the DOM is re-rendered via `updateDom` (#3534)
 
 ### Removed
 

--- a/js/main.js
+++ b/js/main.js
@@ -668,7 +668,7 @@ const MM = (function () {
 			// Further implementation is done in the private method.
 			updateDom(module, updateOptions).then(function () {
 				// Once the update is complete and rendered, send a notification to the module that the DOM has been updated
-				sendNotification("DOM_OBJECTS_UPDATED", null, null, module);
+				sendNotification("MODULE_DOM_UPDATED", null, null, module);
 			});
 		},
 


### PR DESCRIPTION
This is an update to #3535. See #3534 for discussion and context. Fixes #3534 (again).