### PR TITLE
fixes for running tests for MM_MODULES_DIR

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 modules/*
 !modules/default/
+js/positions.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _This release is scheduled to be released on 2024-10-01._
 - [weather] Fixed issue for respecting unit config on broadcasted notifications
 - [tests] Fixes calendar test by moving it from e2e to electron with fixed date (#3532)
 - [calendar] fixed sliceMultiDayEvents getting wrong count and displaying incorrect entries, Europe/Berlin (#3542)
+- [tests] ignore `js/positions.js` when linting (this file is created at runtime)
 
 ## [2.28.0] - 2024-07-01
 

--- a/js/app.js
+++ b/js/app.js
@@ -166,7 +166,15 @@ function App () {
 		let moduleFolder = `${__dirname}/../${env.modulesDir}/${module}`;
 
 		if (defaultModules.includes(moduleName)) {
-			moduleFolder = `${__dirname}/../modules/default/${module}`;
+			const defaultModuleFolder = `${__dirname}/../modules/default/${module}`;
+			if (process.env.JEST_WORKER_ID === undefined) {
+				moduleFolder = defaultModuleFolder;
+			} else {
+				// running in Jest, allow defaultModules placed under moduleDir for testing
+				if (env.modulesDir === "modules") {
+					moduleFolder = defaultModuleFolder;
+				}
+			}
 		}
 
 		const moduleFile = `${moduleFolder}/${module}.js`;

--- a/js/loader.js
+++ b/js/loader.js
@@ -80,7 +80,15 @@ const Loader = (function () {
 			let moduleFolder = `${envVars.modulesDir}/${module}`;
 
 			if (defaultModules.indexOf(moduleName) !== -1) {
-				moduleFolder = `modules/default/${module}`;
+				const defaultModuleFolder = `modules/default/${module}`;
+				if (window.name !== "jsdom") {
+					moduleFolder = defaultModuleFolder;
+				} else {
+					// running in Jest, allow defaultModules placed under moduleDir for testing
+					if (envVars.modulesDir === "modules") {
+						moduleFolder = defaultModuleFolder;
+					}
+				}
 			}
 
 			if (moduleData.disabled === true) {

--- a/tests/e2e/modules/newsfeed_spec.js
+++ b/tests/e2e/modules/newsfeed_spec.js
@@ -82,10 +82,10 @@ describe("Newsfeed module", () => {
 });
 
 describe("Newsfeed module located in config directory", () => {
-	beforeAll(async () => {
+	beforeAll(() => {
 		const baseDir = `${__dirname}/../../..`;
 		if (!fs.existsSync(`${baseDir}/config/newsfeed`)) {
-			await fs.cp(`${baseDir}/modules/default/newsfeed`, `${baseDir}/config/newsfeed`, { recursive: true }, (err) => err && console.error(err));
+			fs.cpSync(`${baseDir}/modules/default/newsfeed`, `${baseDir}/config/newsfeed`, { recursive: true });
 		}
 		process.env.MM_MODULES_DIR = "config";
 	});


### PR DESCRIPTION
and ignore `js/positions.js` when linting (because this file is generated at runtime).
