### PR TITLE
fix calendar showing previous day when using sliceMultiDayEvents

### DIFF
--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -644,7 +644,7 @@ Module.register("calendar", {
 						const thisEvent = JSON.parse(JSON.stringify(event)); // clone object
 						thisEvent.today = thisEvent.startDate >= today && thisEvent.startDate < today + ONE_DAY;
 						thisEvent.tomorrow = !thisEvent.today && thisEvent.startDate >= today + ONE_DAY && thisEvent.startDate < today + 2 * ONE_DAY;
-						thisEvent.endDate = midnight;
+						thisEvent.endDate = moment(midnight, "x").clone().subtract(1, "day").format("x");
 						thisEvent.title += ` (${count}/${maxCount})`;
 						splitEvents.push(thisEvent);
 


### PR DESCRIPTION
This bug is caused by #3543.

The calculation for midnight adds a day but for endDate we want the day to be subtracted again.