### PR TITLE
fix calendar showing previous day when using sliceMultiDayEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ _This release is scheduled to be released on 2024-10-01._
 - [tests] Fixes calendar test by moving it from e2e to electron with fixed date (#3532)
 - [calendar] fixed sliceMultiDayEvents getting wrong count and displaying incorrect entries, Europe/Berlin (#3542)
 - [tests] ignore `js/positions.js` when linting (this file is created at runtime)
+- [calendar] fixed sliceMultiDayEvents showing previous day without config enabled
 
 ## [2.28.0] - 2024-07-01
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -651,7 +651,7 @@ Module.register("calendar", {
 						const thisEvent = JSON.parse(JSON.stringify(event)); // clone object
 						thisEvent.today = thisEvent.startDate >= today && thisEvent.startDate < today + ONE_DAY;
 						thisEvent.tomorrow = !thisEvent.today && thisEvent.startDate >= today + ONE_DAY && thisEvent.startDate < today + 2 * ONE_DAY;
-						thisEvent.endDate = midnight;
+						thisEvent.endDate = moment(midnight, "x").clone().subtract(1, "day").format("x");
 						thisEvent.title += ` (${count}/${maxCount})`;
 						splitEvents.push(thisEvent);
 


### PR DESCRIPTION
This bug is caused by #3543.

The calculation for midnight adds a day but for endDate we want the day to be subtracted again.