### PR TITLE
Updated minimal needed node version in `package.json` (currently v20.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ _This release is scheduled to be released on 2024-10-01._
 - [core] Updated SocketIO catch all to new API
 - [core] Allow custom modules positions by scanning index.html for the defined regions, instead of hard coded (PR #3518 fixes issue #3504)
 - [core] Detail optimizations in `config_check.js`
+- [core] Updated minimal needed node version in `package.json` (currently v20.9.0)
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
 				"stylelint-prettier": "^5.0.2"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=20.9.0"
 			},
 			"optionalDependencies": {
 				"electron": "^31.6.0"

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
 		"electron": "^31.6.0"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=20.9.0"
 	},
 	"_moduleAliases": {
 		"node_helper": "js/node_helper.js",


### PR DESCRIPTION
Update of package*.json for minimal node verion requirement (v20.9.0)

 * it's an addition to #3556
 * According to changelog v2.28.0: `⚠️ This release needs nodejs version >= v20.9.0`
