### PR TITLE
Electron rebuild tests update

### DIFF
--- a/.github/workflows/electron-rebuild.yaml
+++ b/.github/workflows/electron-rebuild.yaml
@@ -21,8 +21,10 @@ jobs:
         run: npm run install-mm
       - name: Install @electron/rebuild
         run: npm install @electron/rebuild
+      - name: Install node-libgpiod deps
+        run: sudo apt-get install gpiod libgpiod2 libgpiod-dev
       - name: Install some test library to be rebuilded
-        run: npm install onoff node-pty drivelist
+        run: npm install node-libgpiod node-pty drivelist
       - name: Run electron-rebuild
         run: npx electron-rebuild
         continue-on-error: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,14 @@ _This release is scheduled to be released on 2024-10-01._
 - [core] elements are now removed from `index.html` when loading script or stylesheet files fails
 - [core] Added `MODULE_DOM_UPDATED` notification each time the DOM is re-rendered via `updateDom` (#3534)
 - [tests] added minimal needed node version to tests (currently v20.9.0) to avoid releases with wrong node version info
-- [tests] Added `node-libgpiod` library to electron-rebuild tests (#)
+- [tests] Added `node-libgpiod` library to electron-rebuild tests (#3563)
 
 ### Removed
 
 - [core] removed installer only files (#3492)
 - [core] removed raspberry object from systeminformation (#3505)
 - [linter] removed `eslint-plugin-import`, because it doesn't support ESLint v9. We will reenter it later when it does.
-- [tests] removed `onoff` library from electron-rebuild tests (#)
+- [tests] removed `onoff` library from electron-rebuild tests (#3563)
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,14 @@ _This release is scheduled to be released on 2024-10-01._
 - [core] elements are now removed from `index.html` when loading script or stylesheet files fails
 - [core] Added `MODULE_DOM_UPDATED` notification each time the DOM is re-rendered via `updateDom` (#3534)
 - [tests] added minimal needed node version to tests (currently v20.9.0) to avoid releases with wrong node version info
+- [tests] Added `node-libgpiod` library to electron-rebuild tests (#)
 
 ### Removed
 
 - [core] removed installer only files (#3492)
 - [core] removed raspberry object from systeminformation (#3505)
 - [linter] removed `eslint-plugin-import`, because it doesn't support ESLint v9. We will reenter it later when it does.
+- [tests] removed `onoff` library from electron-rebuild tests (#)
 
 ### Updated
 


### PR DESCRIPTION
# Update electron-rebuild.yaml
 * remove onoff library: Not updated since 3 years, don't work with last rpi Os
 * add node-libgpiod library in replacement