### PR TITLE
fix double load of positions now that check:config at startup is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ _This release is scheduled to be released on 2024-10-01._
 - [core] Detail optimizations in `config_check.js`
 - [core] Updated minimal needed node version in `package.json` (currently v20.9.0) (#3559) and except for v21 (no security updates) (#3561)
 - [linter] Switch to ESLint v9 and flat config and replace `eslint-plugin-unicorn` by `@eslint/js`
+- [core] fix discovering module positions twice after #3450
 
 ### Fixed
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -49,21 +49,24 @@ module.exports = {
 	},
 
 	getModulePositions () {
-		// get the lines of the index.html
-		const lines = fs.readFileSync(indexFileName).toString().split(os.EOL);
-		// loop thru the lines
-		lines.forEach((line) => {
-			// run the regex on each line
-			const results = regionRegEx.exec(line);
-			// if the regex returned something
-			if (results && results.length > 0) {
-				// get the position parts and replace space with underscore
-				const positionName = results[1].replace(" ", "_");
-				// add it to the list
-				modulePositions.push(positionName);
-			}
-		});
-		fs.writeFileSync(discoveredPositionsJSFilename, `const modulePositions=${JSON.stringify(modulePositions)}`);
+		// if not already discovered
+		if (modulePositions.length === 0) {
+			// get the lines of the index.html
+			const lines = fs.readFileSync(indexFileName).toString().split(os.EOL);
+			// loop thru the lines
+			lines.forEach((line) => {
+				// run the regex on each line
+				const results = regionRegEx.exec(line);
+				// if the regex returned something
+				if (results && results.length > 0) {
+					// get the position parts and replace space with underscore
+					const positionName = results[1].replace(" ", "_");
+					// add it to the list
+					modulePositions.push(positionName);
+				}
+			});
+			fs.writeFileSync(discoveredPositionsJSFilename, `const modulePositions=${JSON.stringify(modulePositions)}`);
+		}
 		// return the list to the caller
 		return modulePositions;
 	}


### PR DESCRIPTION
after adding check:config to the MM startup process, #3450,  we accidentally discover module positions more than once, and write the file each time..

add a check to see if we have done this work already
