### PR TITLE
[Electron rebuild] Removed node-pty and drivelist from rebuilded test

### DIFF
--- a/.github/workflows/electron-rebuild.yaml
+++ b/.github/workflows/electron-rebuild.yaml
@@ -23,8 +23,8 @@ jobs:
         run: npm install @electron/rebuild
       - name: Install node-libgpiod deps
         run: sudo apt-get install gpiod libgpiod2 libgpiod-dev
-      - name: Install some test library to be rebuilded
-        run: npm install node-libgpiod node-pty drivelist
+      - name: Install test library (node-libgpiod) to be rebuilded
+        run: npm install node-libgpiod
       - name: Run electron-rebuild
         run: npx electron-rebuild
         continue-on-error: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ _This release is scheduled to be released on 2025-01-01._
 
 ### Removed
 
-- [tests] Removed node-pty and drivelist from rebuilded test
+- [tests] Removed node-pty and drivelist from rebuilded test (#3575)
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ _This release is scheduled to be released on 2025-01-01._
 
 ### Removed
 
+- [tests] Removed node-pty and drivelist from rebuilded test
+
 ### Updated
 
 ### Fixed


### PR DESCRIPTION
Related to #3573 

I think it's better to keep new library node-libgpiod for testing (library to manage RPI gpio for pir sensor management) and delete others
Only one test is better

