### PR TITLE
[UpdateNotification] Fix pm2 using detection when pm2 script is in MagicMirror root folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ _This release is scheduled to be released on 2025-01-01._
 
 ### Fixed
 
+- [updatenotification] Fix pm2 using detection when pm2 script is in MagicMirror root folder
+
 ## [2.29.0] - 2024-10-01
 
 Thanks to: @bugsounet, @dkallen78, @jargordon, @khassel, @KristjanESPERANTO, @MarcLandis, @rejas, @ryan-d-williams, @sdetweil, @skpanagiotis.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ _This release is scheduled to be released on 2025-01-01._
 
 ### Fixed
 
-- [updatenotification] Fix pm2 using detection when pm2 script is in MagicMirror root folder
+- [updatenotification] Fix pm2 using detection when pm2 script is in MagicMirror root folder (#3576)
 
 ## [2.29.0] - 2024-10-01
 

--- a/modules/default/updatenotification/update_helper.js
+++ b/modules/default/updatenotification/update_helper.js
@@ -187,7 +187,7 @@ class Updater {
 						return;
 					}
 					list.forEach((pm) => {
-						if (pm.pm2_env.version === this.version && pm.pm2_env.status === "online" && pm.pm2_env.pm_cwd.includes(`${this.root_path}/`)) {
+						if (pm.pm2_env.version === this.version && pm.pm2_env.status === "online" && pm.pm2_env.pm_cwd.includes(`${this.root_path}`)) {
 							this.PM2 = pm.name;
 							this.usePM2 = true;
 							Log.info("updatenotification: [PM2] You are using pm2 with", this.PM2);


### PR DESCRIPTION
I discover this bug:

When pm2 `sh` script is on MagicMirror root folder, updatenotification is not able to detect pm2 using

```
0|MagicMirror  | [2024-10-02 17:23:09.215] [DEBUG]   Version Compare: 2.30.0-develop 2.30.0-develop --> true 
0|MagicMirror  | [2024-10-02 17:23:09.216] [DEBUG]   Status: online 
0|MagicMirror  | [2024-10-02 17:23:09.216] [DEBUG]   PM2 MagicMirror starting  from Path: /home/bugsounet/MagicMirror-dev 
0|MagicMirror  | [2024-10-02 17:23:09.216] [DEBUG]   MagicMirror Path /home/bugsounet/MagicMirror-dev/
0|MagicMirror  | [2024-10-02 17:23:09.216] [DEBUG]   Compare: false
0|MagicMirror  | [2024-10-02 17:23:09.216] [INFO]  updatenotification: [PM2] You are not using pm2 
```
