### PR TITLE
[core] add try / catch on mode_helper loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ _This release is scheduled to be released on 2025-01-01._
 ### Fixed
 
 - [updatenotification] Fix pm2 using detection when pm2 script is in MagicMirror root folder (#3576)
-- [core] Fix loading node_helper of modules: avoid black screen, display errors and continue loading with next module (#xxxx)
+- [core] Fix loading node_helper of modules: avoid black screen, display errors and continue loading with next module (#3578)
 
 ## [2.29.0] - 2024-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ _This release is scheduled to be released on 2025-01-01._
 ### Fixed
 
 - [updatenotification] Fix pm2 using detection when pm2 script is in MagicMirror root folder (#3576)
+- [core] Fix loading node_helper of modules: avoid black screen, display errors and continue loading with next module (#xxxx)
 
 ## [2.29.0] - 2024-10-01
 

--- a/js/app.js
+++ b/js/app.js
@@ -197,7 +197,13 @@ function App () {
 
 		// if the helper was found
 		if (loadHelper) {
-			const Module = require(helperPath);
+			let Module;
+			try {
+				Module = require(helperPath);
+			} catch (e) {
+				Log.error(`Error when loading ${moduleName}:`, e.message);
+				return;
+			}
 			let m = new Module();
 
 			if (m.requiresVersion) {


### PR DESCRIPTION
When a library is missing on an 3rd party module, MM² stop loading and display a black screen. (I'm sure it's happened to everyone.)

So, I have added a try/catch block and it's avoid black screen, display errors and allow continue loading with next module
