### PR TITLE
fix electron tests mocking dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ _This release is scheduled to be released on 2025-01-01._
 - [updatenotification] Fix pm2 using detection when pm2 script is in MagicMirror root folder (#3576)
 - [core] Fix loading node_helper of modules: avoid black screen, display errors and continue loading with next module (#3578)
 - [weather] changed default value for weatherEndpoint of provider openweathermap to "/onecall" (#3574)
-- [calendar] fix one testcase which had a date expired problem..
+- [tests] fix electron tests with mock dates, the mock on server side was missing (#3597)
 
 ## [2.29.0] - 2024-10-01
 

--- a/js/electron.js
+++ b/js/electron.js
@@ -79,7 +79,6 @@ function createWindow () {
 	if (process.env.JEST_WORKER_ID !== undefined && process.env.MOCK_DATE !== undefined) {
 		// if we are running with jest and we want to mock the current date
 		const fakeNow = new Date(process.env.MOCK_DATE).valueOf();
-		global.originalDate = global.Date;
 		Date = class extends Date {
 			constructor (...args) {
 				if (args.length === 0) {

--- a/js/electron.js
+++ b/js/electron.js
@@ -76,6 +76,24 @@ function createWindow () {
 
 	const electronOptions = Object.assign({}, electronOptionsDefaults, config.electronOptions);
 
+	if (process.env.JEST_WORKER_ID !== undefined && process.env.MOCK_DATE !== undefined) {
+		// if we are running with jest and we want to mock the current date
+		const fakeNow = new Date(process.env.MOCK_DATE).valueOf();
+		global.originalDate = global.Date;
+		Date = class extends Date {
+			constructor (...args) {
+				if (args.length === 0) {
+					super(fakeNow);
+				} else {
+					super(...args);
+				}
+			}
+		};
+		const __DateNowOffset = fakeNow - Date.now();
+		const __DateNow = Date.now;
+		Date.now = () => __DateNow() + __DateNowOffset;
+	}
+
 	// Create the browser window.
 	mainWindow = new BrowserWindow(electronOptions);
 

--- a/js/server.js
+++ b/js/server.js
@@ -72,11 +72,7 @@ function Server (config) {
 			app.use(helmet(config.httpHeaders));
 			app.use("/js", express.static(__dirname));
 
-			let directories = ["/config", "/css", "/fonts", "/modules", "/vendor", "/translations"];
-			if (process.env.JEST_WORKER_ID !== undefined) {
-				// add tests directories only when running tests
-				directories.push("/tests/configs", "/tests/mocks");
-			}
+			let directories = ["/config", "/css", "/fonts", "/modules", "/vendor", "/translations", "/tests/configs", "/tests/mocks"];
 			for (const directory of directories) {
 				app.use(directory, express.static(path.resolve(global.root_path + directory)));
 			}

--- a/tests/configs/modules/calendar/custom.js
+++ b/tests/configs/modules/calendar/custom.js
@@ -13,6 +13,8 @@ let config = {
 				calendars: [
 					{
 						maximumEntries: 5,
+						pastDaysCount: 5,
+						broadcastPastEvents: true,
 						maximumNumberOfDays: 10000,
 						symbol: "birthday-cake",
 						fullDaySymbol: "calendar-day",

--- a/tests/configs/modules/calendar/show-duplicates-in-calendar.js
+++ b/tests/configs/modules/calendar/show-duplicates-in-calendar.js
@@ -27,10 +27,6 @@ let config = {
 	]
 };
 
-Date.now = () => {
-	return new Date("15 Sep 2024 12:30:00 GMT").valueOf();
-};
-
 /*************** DO NOT EDIT THE LINE BELOW ***************/
 if (typeof module !== "undefined") {
 	module.exports = config;

--- a/tests/electron/helpers/global-setup.js
+++ b/tests/electron/helpers/global-setup.js
@@ -8,6 +8,10 @@ exports.startApplication = async (configFilename, systemDate = null, electronPar
 	global.page = null;
 	process.env.MM_CONFIG_FILE = configFilename;
 	process.env.TZ = timezone;
+	if (systemDate) {
+		process.env.MOCK_DATE = systemDate;
+	}
+
 	global.electronApp = await electron.launch({ args: electronParams });
 
 	await global.electronApp.firstWindow();
@@ -34,6 +38,7 @@ exports.stopApplication = async () => {
 	}
 	global.electronApp = null;
 	global.page = null;
+	process.env.MOCK_DATE = undefined;
 };
 
 exports.getElement = async (selector) => {


### PR DESCRIPTION
fixes #3597 

Changes:
- electron tests: add mocking to `electron.js` for mocking the server side, before only the browser side was mocked
- publish "/tests/configs" and "/tests/mocks" always in `server.js`, this reverts a change done with latest release, we need this for debugging (otherwise you get on the screen that your config has errors but config check is successful ...)
- revert hotfix in `tests/configs/modules/calendar/show-duplicates-in-calendar.js`
- fix `tests/configs/modules/calendar/custom.js` to allow events in the past (~~I don't know how this could work before~~ when testing  css classes `yesterday` and `dayBeforeYesterday` --> it worked before because the server side did not mock and therefore was not in the past)