### PR TITLE
[updatenotification] Fix pm2 using detection when pm2 script is inside or outside MagicMirror root folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ _This release is scheduled to be released on 2025-01-01._
 
 ### Fixed
 
-- [updatenotification] Fix pm2 using detection when pm2 script is in MagicMirror root folder (#3576)
+- [updatenotification] Fix pm2 using detection when pm2 script is inside or outside MagicMirror root folder (#3576) (#3605)
 - [core] Fix loading node_helper of modules: avoid black screen, display errors and continue loading with next module (#3578)
 - [weather] changed default value for weatherEndpoint of provider openweathermap to "/onecall" (#3574)
 - [tests] fix electron tests with mock dates, the mock on server side was missing (#3597)

--- a/modules/default/updatenotification/update_helper.js
+++ b/modules/default/updatenotification/update_helper.js
@@ -187,7 +187,9 @@ class Updater {
 						return;
 					}
 					list.forEach((pm) => {
-						if (pm.pm2_env.version === this.version && pm.pm2_env.status === "online" && pm.pm2_env.pm_cwd.includes(`${this.root_path}`)) {
+						Log.debug(`[PM2] pm2 name: ${pm.name} -- in process env: ${process.env.name}`)
+						Log.debug(`[PM2] pm2 pm_id: ${pm.pm_id} -- in process env: ${process.env.pm_id}`)
+						if (pm.pm2_env.status === "online" && process.env.name === pm.name && +process.env.pm_id === +pm.pm_id) {
 							this.PM2 = pm.name;
 							this.usePM2 = true;
 							Log.info("updatenotification: [PM2] You are using pm2 with", this.PM2);


### PR DESCRIPTION
This will fix #3576 

@FrankBlackMG: 

I don't use `*env.unique_id` because some others modules can use pm2 too for starting a service and unique_id is the same (this will make confusion)
So I check `name` and `pm_id` for found it

