### PR TITLE
fix missing basePath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ _This release is scheduled to be released on 2025-01-01._
 - [weather] changed default value for weatherEndpoint of provider openweathermap to "/onecall" (#3574)
 - [tests] fix electron tests with mock dates, the mock on server side was missing (#3597)
 - [tests] fix testcases with hard coded Date.now (#3597)
+- [core] Fix missing `basePath` where `location.host` is used (#3613)
 
 ## [2.29.0] - 2024-10-01
 

--- a/js/loader.js
+++ b/js/loader.js
@@ -15,7 +15,7 @@ const Loader = (function () {
 	 * @returns {object} with key: values as assembled in js/server_functions.js
 	 */
 	const getEnvVars = async function () {
-		const res = await fetch(`${location.protocol}//${location.host}/env`);
+		const res = await fetch(`${location.protocol}//${location.host}${config.basePath}env`);
 		return JSON.parse(await res.text());
 	};
 

--- a/js/main.js
+++ b/js/main.js
@@ -608,7 +608,7 @@ const MM = (function () {
 					// if server startup time has changed (which means server was restarted)
 					// the client reloads the mm page
 					try {
-						const res = await fetch(`${location.protocol}//${location.host}/startup`);
+						const res = await fetch(`${location.protocol}//${location.host}${config.basePath}startup`);
 						const curr = await res.text();
 						if (startUp === "") startUp = curr;
 						if (startUp !== curr) {

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -38,7 +38,7 @@ Module.register("newsfeed", {
 
 	getUrlPrefix (item) {
 		if (item.useCorsProxy) {
-			return `${location.protocol}//${location.host}/cors?url=`;
+			return `${location.protocol}//${location.host}${config.basePath}cors?url=`;
 		} else {
 			return "";
 		}

--- a/modules/default/utils.js
+++ b/modules/default/utils.js
@@ -5,13 +5,14 @@
  * @param {boolean} useCorsProxy A flag to indicate
  * @param {Array.<{name: string, value:string}>} requestHeaders the HTTP headers to send
  * @param {Array.<string>} expectedResponseHeaders the expected HTTP headers to receive
+ * @param {string} basePath, default /
  * @returns {Promise} resolved when the fetch is done. The response headers is placed in a headers-property (provided the response does not already contain a headers-property).
  */
-async function performWebRequest (url, type = "json", useCorsProxy = false, requestHeaders = undefined, expectedResponseHeaders = undefined) {
+async function performWebRequest (url, type = "json", useCorsProxy = false, requestHeaders = undefined, expectedResponseHeaders = undefined, basePath = "/") {
 	const request = {};
 	let requestUrl;
 	if (useCorsProxy) {
-		requestUrl = getCorsUrl(url, requestHeaders, expectedResponseHeaders);
+		requestUrl = getCorsUrl(url, requestHeaders, expectedResponseHeaders, basePath);
 	} else {
 		requestUrl = url;
 		request.headers = getHeadersToSend(requestHeaders);
@@ -37,13 +38,14 @@ async function performWebRequest (url, type = "json", useCorsProxy = false, requ
  * @param {string} url the url to fetch from
  * @param {Array.<{name: string, value:string}>} requestHeaders the HTTP headers to send
  * @param {Array.<string>} expectedResponseHeaders the expected HTTP headers to receive
+ * @param {string} basePath, default /
  * @returns {string} to be used as URL when calling CORS-method on server.
  */
-const getCorsUrl = function (url, requestHeaders, expectedResponseHeaders) {
+const getCorsUrl = function (url, requestHeaders, expectedResponseHeaders, basePath = "/") {
 	if (!url || url.length < 1) {
 		throw new Error(`Invalid URL: ${url}`);
 	} else {
-		let corsUrl = `${location.protocol}//${location.host}/cors?`;
+		let corsUrl = `${location.protocol}//${location.host}${basePath}cors?`;
 
 		const requestHeaderString = getRequestHeaderString(requestHeaders);
 		if (requestHeaderString) corsUrl = `${corsUrl}sendheaders=${requestHeaderString}`;

--- a/modules/default/weather/weatherprovider.js
+++ b/modules/default/weather/weatherprovider.js
@@ -119,7 +119,7 @@ const WeatherProvider = Class.extend({
 			return JSON.parse(data);
 		}
 		const useCorsProxy = typeof this.config.useCorsProxy !== "undefined" && this.config.useCorsProxy;
-		return performWebRequest(url, type, useCorsProxy, requestHeaders, expectedResponseHeaders);
+		return performWebRequest(url, type, useCorsProxy, requestHeaders, expectedResponseHeaders, config.basePath);
 	}
 });
 


### PR DESCRIPTION
fixes #3613 

wanted to write a test for `basePath` but have no idea at the moment to simulate this without a reverse proxy.

Here my test setup for documentation:
```yaml
networks:
  proxy:
    driver: bridge

services:
  socket-proxy:
    privileged: true
    image: tecnativa/docker-socket-proxy:edge
    container_name: socket-proxy
    restart: unless-stopped
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock:ro
    environment:
      CONTAINERS: 1
    ports:
      - "127.0.0.1:2375:2375"
    networks:
      - proxy

  traefik:
    image: traefik:latest
    container_name: traefik
    restart: unless-stopped
    user: 1000:1000
    command:
      - "--providers.docker=true"
      - "--providers.docker.network=traefik_proxy"
      - "--providers.docker.endpoint=tcp://socket-proxy:2375"
      - "--entryPoints.http.address=:80"
      - "--global.sendAnonymousUsage=false"
      - "--log.level=INFO"
      - "--api=true"
      - "--api.dashboard=true"
#      - "--accessLog=true"
#      - "--accesslog.fields.defaultmode=keep"
#      - "--accesslog.fields.headers.defaultmode=keep"
    networks:
      - proxy
    ports:
      - "80:80"

  magicmirror:
    image: karsten13/magicmirror:develop
    container_name: mm
    restart: unless-stopped
    entrypoint:
      - sleep
      - infinity
    networks:
      - proxy
    labels:
      - "traefik.http.services.karsten13.loadbalancer.server.port=8080"
      - "traefik.http.routers.k13-http.service=karsten13"
      - "traefik.http.routers.k13-http.entrypoints=http"
      - "traefik.http.routers.k13-http.rule=Host(`localhost`) && PathPrefix(`/testbasepath`)"
      - "traefik.http.middlewares.k13-stripprefix.stripprefix.prefixes=/testbasepath"
      - "traefik.http.routers.k13-http.middlewares=k13-stripprefix"
```