### PR TITLE
Fix compliments croner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ _This release is scheduled to be released on 2025-01-01._
 - [tests] Fix electron tests with mock dates, the mock on server side was missing (#3597)
 - [tests] Fix test cases with hard coded Date.now (#3597)
 - [core] Fix missing `basePath` where `location.host` is used (#3613)
+- [compliments] croner library changed filenames used in latest version (#3624)
 
 ## [2.29.0] - 2024-10-01
 

--- a/vendor/package.json
+++ b/vendor/package.json
@@ -13,7 +13,7 @@
 	"dependencies": {
 		"@fortawesome/fontawesome-free": "^6.6.0",
 		"animate.css": "^4.1.1",
-		"croner": "^8.1.2",
+		"croner": "^9.0.0",
 		"moment": "^2.30.1",
 		"moment-timezone": "^0.5.46",
 		"nunjucks": "^3.2.4",

--- a/vendor/vendor.js
+++ b/vendor/vendor.js
@@ -6,7 +6,7 @@ const vendor = {
 	"font-awesome.css": "css/font-awesome.css",
 	"nunjucks.js": "node_modules/nunjucks/browser/nunjucks.min.js",
 	"suncalc.js": "node_modules/suncalc/suncalc.js",
-	"croner.js": "node_modules/croner/dist/croner.umd.min.js"
+	"croner.js": "node_modules/croner/dist/croner.umd.js"
 };
 
 if (typeof module !== "undefined") {


### PR DESCRIPTION
croner changed the filename we need to use in the latest version
fix the alias table in vendor/vendor.js

fixes #3624 