### PR TITLE
add support for test mode detection in modulename.js via index.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ _This release is scheduled to be released on 2025-01-01._
 - [linter] re-added `eslint-plugin-import`now that it supports ESLint v9 (#3586)
 - [docs] Added step for npm publishing in release process (#3595)
 - [core] Add GitHub workflow to run spellcheck a few days before each release.
+- [core] Add intest flag to index.html to pass to module js for test mode detection (needed by #3630)
 
 ### Removed
 

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 
     <script type="text/javascript">
       window.mmVersion = "#VERSION#";
-      window.intest = "#TESTMODE#";
+      window.mmTestMode = "#TESTMODE#";
     </script>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
 
     <script type="text/javascript">
       window.mmVersion = "#VERSION#";
+      window.intest = "#TESTMODE#";
     </script>
   </head>
   <body>

--- a/js/app.js
+++ b/js/app.js
@@ -13,6 +13,7 @@ const { getEnvVarsAsObj } = require(`${__dirname}/server_functions`);
 
 // Get version number.
 global.version = require(`${__dirname}/../package.json`).version;
+global.intest = process.env.intest ? true : false;
 Log.log(`Starting MagicMirror: v${global.version}`);
 
 // Log system information.

--- a/js/app.js
+++ b/js/app.js
@@ -13,7 +13,7 @@ const { getEnvVarsAsObj } = require(`${__dirname}/server_functions`);
 
 // Get version number.
 global.version = require(`${__dirname}/../package.json`).version;
-global.intest = process.env.intest ? true : false;
+global.mmTestMode = process.env.mmTestMode === "true" ? true : false;
 Log.log(`Starting MagicMirror: v${global.version}`);
 
 // Log system information.

--- a/js/server_functions.js
+++ b/js/server_functions.js
@@ -109,6 +109,7 @@ function geExpectedReceivedHeaders (url) {
 function getHtml (req, res) {
 	let html = fs.readFileSync(path.resolve(`${global.root_path}/index.html`), { encoding: "utf8" });
 	html = html.replace("#VERSION#", global.version);
+	html = html.replace("#TESTMODE#", global.intest);
 
 	let configFile = "config/config.js";
 	if (typeof global.configuration_file !== "undefined") {

--- a/js/server_functions.js
+++ b/js/server_functions.js
@@ -109,7 +109,7 @@ function geExpectedReceivedHeaders (url) {
 function getHtml (req, res) {
 	let html = fs.readFileSync(path.resolve(`${global.root_path}/index.html`), { encoding: "utf8" });
 	html = html.replace("#VERSION#", global.version);
-	html = html.replace("#TESTMODE#", global.intest);
+	html = html.replace("#TESTMODE#", global.mmTestMode);
 
 	let configFile = "config/config.js";
 	if (typeof global.configuration_file !== "undefined") {

--- a/tests/e2e/helpers/global-setup.js
+++ b/tests/e2e/helpers/global-setup.js
@@ -26,6 +26,7 @@ exports.startApplication = async (configFilename, exec) => {
 	} else {
 		process.env.MM_CONFIG_FILE = configFilename;
 	}
+	process.env.intest = true;
 	if (exec) exec;
 	global.app = require("../../../js/app");
 

--- a/tests/e2e/helpers/global-setup.js
+++ b/tests/e2e/helpers/global-setup.js
@@ -26,7 +26,7 @@ exports.startApplication = async (configFilename, exec) => {
 	} else {
 		process.env.MM_CONFIG_FILE = configFilename;
 	}
-	process.env.intest = true;
+	process.env.mmTestMode = "true";
 	if (exec) exec;
 	global.app = require("../../../js/app");
 

--- a/tests/electron/helpers/global-setup.js
+++ b/tests/electron/helpers/global-setup.js
@@ -11,6 +11,7 @@ exports.startApplication = async (configFilename, systemDate = null, electronPar
 	if (systemDate) {
 		process.env.MOCK_DATE = systemDate;
 	}
+	process.env.intest = true;
 
 	global.electronApp = await electron.launch({ args: electronParams });
 
@@ -39,6 +40,7 @@ exports.stopApplication = async () => {
 	global.electronApp = null;
 	global.page = null;
 	process.env.MOCK_DATE = undefined;
+	process.env.jstest = undefined;
 };
 
 exports.getElement = async (selector) => {

--- a/tests/electron/helpers/global-setup.js
+++ b/tests/electron/helpers/global-setup.js
@@ -11,7 +11,7 @@ exports.startApplication = async (configFilename, systemDate = null, electronPar
 	if (systemDate) {
 		process.env.MOCK_DATE = systemDate;
 	}
-	process.env.intest = true;
+	process.env.mmTestMode = "true";
 
 	global.electronApp = await electron.launch({ args: electronParams });
 

--- a/tests/electron/helpers/global-setup.js
+++ b/tests/electron/helpers/global-setup.js
@@ -40,7 +40,6 @@ exports.stopApplication = async () => {
 	global.electronApp = null;
 	global.page = null;
 	process.env.MOCK_DATE = undefined;
-	process.env.jstest = undefined;
 };
 
 exports.getElement = async (selector) => {


### PR DESCRIPTION
in some cases the modulename.js may need to detect running in test mode (compliments pr #3630)

window.name is not set  web mode

add a new field to the index.html 
window.intest 
and use the server_function to replace the  hard coded string like we do for window.mmversion=#VERSION#
then change the two  test helpers to set the env variable
app.js detects and sets global.intest=true
server func replace with value of global.intest

then module can use   if(window.intest)
