### PR TITLE
Remove `@eslint/js` dependency. Already installed with `eslint` in deep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ _This release is scheduled to be released on 2025-01-01._
 ### Removed
 
 - [tests] Removed node-pty and drivelist from rebuilded test (#3575)
-- [deps] Remove `@eslint/js` dependency. Already installed with `eslint` in deep (#3XXX)
+- [deps] Remove `@eslint/js` dependency. Already installed with `eslint` in deep (#3636)
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ _This release is scheduled to be released on 2025-01-01._
 ### Removed
 
 - [tests] Removed node-pty and drivelist from rebuilded test (#3575)
+- [deps] Remove `@eslint/js` dependency. Already installed with `eslint` in deep (#3XXX)
 
 ### Updated
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
 				"systeminformation": "^5.23.5"
 			},
 			"devDependencies": {
-				"@eslint/js": "^9.14.0",
 				"@stylistic/eslint-plugin": "^2.10.1",
 				"cspell": "^8.15.7",
 				"eslint-plugin-import": "^2.31.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
 		"systeminformation": "^5.23.5"
 	},
 	"devDependencies": {
-		"@eslint/js": "^9.14.0",
 		"@stylistic/eslint-plugin": "^2.10.1",
 		"cspell": "^8.15.7",
 		"eslint-plugin-import": "^2.31.0",


### PR DESCRIPTION
I lint my modules and just see this:

`@eslint/js` is now not needed.
it's installed by `eslint` it self
