### PR TITLE
fix access denied fault error writing js/positions.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ _This release is scheduled to be released on 2025-01-01._
 - [core] Run code style checks in workflow only once (#3648)
 - [core] Fix animations export #3644 only on server side (#3649)
 - [core] Use project URL in fallback config.
-- [core] fix Access Denied crash writing js/positions.js (on synology nas) #3651. new message, MM starts, but no modules showing, positions list empty
+- [core] fix Access Denied crash writing js/positions.js (on synology nas) #3651. new message, MM starts, but no modules showing
 
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ _This release is scheduled to be released on 2025-01-01._
 
 - [core] Run code style checks in workflow only once.
 - [core] fix animations export #3644 only on server side
+- [core] fix Access Denied crash writing js/positions.js (on synology nas) #3651. new message, MM starts, but no modules showing, positions list empty
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ _This release is scheduled to be released on 2025-01-01._
 - [core] Use project URL in fallback config.
 - [core] fix Access Denied crash writing js/positions.js (on synology nas) #3651. new message, MM starts, but no modules showing
 
-
 ### Removed
 
 - [tests] Remove `node-pty` and `drivelist` from rebuilded test (#3575)

--- a/js/utils.js
+++ b/js/utils.js
@@ -65,7 +65,12 @@ module.exports = {
 					modulePositions.push(positionName);
 				}
 			});
-			fs.writeFileSync(discoveredPositionsJSFilename, `const modulePositions=${JSON.stringify(modulePositions)}`);
+			try {
+				fs.writeFileSync(discoveredPositionsJSFilename, `const modulePositions=${JSON.stringify(modulePositions)}`);
+			}
+			catch (error) {
+				console.error("unable to write js/positions.js with the discovered module positions\nmake the MagicMirror/js folder writeable by the user starting MagicMirror");
+			}
 		}
 		// return the list to the caller
 		return modulePositions;


### PR DESCRIPTION
if the MagicMirror js folder is not writable (synology nas created by different user than docker container) there is an uncaught throw

```
[ERROR] EACCES: permission denied, open 'js/positions.js' 
```

add try/catch, output new message, console.error
```text
unable to write js/positions.js with the discovered module positions
make the MagicMirror/js folder writeable by the user starting MagicMirror 
```

MM will start, but no modules will show, as no positions were discovered
this file is used to pass the list from the server side to the browser side

fixes #3651 