### PR TITLE
path resolve and sub/sub folder module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ _This release is scheduled to be released on 2025-01-01._
 - [calendar] - fix showEnd for Full Day events #3602
 - [tests] Suppress "module is not defined" in e2e tests
 - [calendar] - fixes #3267 (styles array, really this time!)
+- [core] Fix module path in case of sub/sub folder is used and use path.resolve for resolve `moduleFolder` and `defaultModuleFolder` in app.js (#3xxx)
 
 ## [2.29.0] - 2024-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ _This release is scheduled to be released on 2025-01-01._
 - [calendar] - fix showEnd for Full Day events #3602
 - [tests] Suppress "module is not defined" in e2e tests
 - [calendar] - fixes #3267 (styles array, really this time!)
-- [core] Fix module path in case of sub/sub folder is used and use path.resolve for resolve `moduleFolder` and `defaultModuleFolder` in app.js (#3xxx)
+- [core] Fix module path in case of sub/sub folder is used and use path.resolve for resolve `moduleFolder` and `defaultModuleFolder` in app.js (#3653)
 
 ## [2.29.0] - 2024-10-01
 

--- a/js/app.js
+++ b/js/app.js
@@ -164,10 +164,10 @@ function App () {
 		const elements = module.split("/");
 		const moduleName = elements[elements.length - 1];
 		const env = getEnvVarsAsObj();
-		let moduleFolder = `${__dirname}/../${env.modulesDir}/${module}`;
+		let moduleFolder = path.resolve(`${__dirname}/../${env.modulesDir}`, module);
 
 		if (defaultModules.includes(moduleName)) {
-			const defaultModuleFolder = `${__dirname}/../modules/default/${module}`;
+			const defaultModuleFolder = path.resolve(`${__dirname}/../modules/default/`, module);
 			if (process.env.JEST_WORKER_ID === undefined) {
 				moduleFolder = defaultModuleFolder;
 			} else {
@@ -178,7 +178,7 @@ function App () {
 			}
 		}
 
-		const moduleFile = `${moduleFolder}/${module}.js`;
+		const moduleFile = `${moduleFolder}/${moduleName}.js`;
 
 		try {
 			fs.accessSync(moduleFile, fs.R_OK);


### PR DESCRIPTION
Fix:
 - use `path.resolve` for `moduleFolder` and `defaultModuleFolder` path
 -  Fix module path in case of sub/sub folder is used (sample `module/test/test`)
 
---
case of module installation on `module/test/test`:

config will be:
```js
 {
    module: "test/test",
    ...
 }
```

module core will be:
```js
Module.register("test", {
...
```
`test.js` is used for module core (no change)

---

case of module installation on `module/test` (no change):
config will be:
```js
 {
    module: "test",
    ...
 }
```

module core will be:
```js
Module.register("test", {
...
```
so `test.js` is used for module core

---

In reality, with this patch, `module` config feature have 2 functionalites:
 -  determinate module path with more precision
 -  allow to use sub/sub folder in modules folder
 