### PR TITLE
Switch to 'npx' for lint-staged in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-if command -v npm &> /dev/null; then
-  npm run lint:staged
+if command -v npx &> /dev/null; then
+  npx lint-staged
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,14 +23,15 @@ _This release is scheduled to be released on 2025-01-01._
 - [linter] Re-activate `eslint-plugin-package-json` to lint `package.json` (#3643)
 - [linter] Add linting for markdown files (#3646)
 - [calendar] Add ability to display end date for full date events, where end is not same day (showEnd=true) (#3650)
-- [core] Add text to the config.js.sample file about the locale variable (#3654)
+- [core] Add text to the config.js.sample file about the locale variable (#3654, #3655)
 
 ### Changed
 
 - [core] Run code style checks in workflow only once (#3648)
 - [core] Fix animations export #3644 only on server side (#3649)
-- [core] Use project URL in fallback config.
-- [core] fix Access Denied crash writing js/positions.js (on synology nas) #3651. new message, MM starts, but no modules showing
+- [core] Use project URL in fallback config (#3656)
+- [core] Fix Access Denied crash writing js/positions.js (on synology nas) #3651. new message, MM starts, but no modules showing (#3652)
+- [linter] Switch to 'npx' for lint-staged in pre-commit hook
 
 ### Removed
 
@@ -40,7 +41,7 @@ _This release is scheduled to be released on 2025-01-01._
 ### Updated
 
 - [repo] Reactivate `stale.yaml` as GitHub action to mark issues as stale after 60 days and close them 7 days later (if no activity) (#3577, #3580, #3581)
-- [core] Update electron dependency to v32 (test electron rebuild) and other dependencies
+- [core] Update electron dependency to v32 (test electron rebuild) and other dependencies (#3657)
 - [tests] All test configs have been updated to allow full external access, allowing for easier debugging (especially when running as a container)
 - [core] Run and test with node 23 (#3588)
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
 		"lint:js": "eslint . --fix",
 		"lint:markdown": "markdownlint-cli2 . --fix",
 		"lint:prettier": "prettier . --write",
-		"lint:staged": "lint-staged",
 		"postinstall": "npm run install-vendor && npm run install-fonts && echo \"MagicMirror² installation finished successfully! \n\"",
 		"prepare": "[ -f node_modules/.bin/husky ] && husky || echo no husky installed.",
 		"server": "node ./serveronly",


### PR DESCRIPTION
This way we get rid of the script entry in the `package.json` and the whole thing becomes a little less complex.