### PR TITLE
fix #3662 line parse on windows with linux line ends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ _This release is scheduled to be released on 2025-01-01._
 - [calendar] Fix showEnd for Full Day events (#3602)
 - [tests] Suppress "module is not defined" in e2e tests (#3647)
 - [calendar] Fix #3267 (styles array, really this time!)
+- [core] Fix #3662 js/positions.js created incorrectly
 
 ## [2.29.0] - 2024-10-01
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -52,7 +52,7 @@ module.exports = {
 		// if not already discovered
 		if (modulePositions.length === 0) {
 			// get the lines of the index.html
-			const lines = fs.readFileSync(indexFileName).toString().split(os.EOL);
+			const lines = fs.readFileSync(indexFileName).toString().split("\n");
 			// loop thru the lines
 			lines.forEach((line) => {
 				// run the regex on each line


### PR DESCRIPTION
line parse used os.EOL, which failed with linux line ends in index.html, change to '\n'