### PR TITLE
Add some ESLint rules + minor changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ _This release is scheduled to be released on 2025-01-01._
 - [linter] Re-add `eslint-plugin-import`now that it supports ESLint v9 (#3586)
 - [linter] Re-activate `eslint-plugin-package-json` to lint `package.json` (#3643)
 - [linter] Add linting for markdown files (#3646)
+- [linter] Add some handy ESLint rules.
 - [calendar] Add ability to display end date for full date events, where end is not same day (showEnd=true) (#3650)
 - [core] Add text to the config.js.sample file about the locale variable (#3654, #3655)
 - [core] Add fetch timeout for all node_helpers (thru undici, forces node 20.18.1 minimum) to help on slower systems. (#3660) (3661)

--- a/clientonly/index.js
+++ b/clientonly/index.js
@@ -28,7 +28,7 @@
 		});
 
 		// determine if "--use-tls"-flag was provided
-		config["tls"] = process.argv.indexOf("--use-tls") > 0;
+		config.tls = process.argv.indexOf("--use-tls") > 0;
 	}
 
 	/**

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -152,6 +152,7 @@
 		"newsitems",
 		"nfogal",
 		"njwilliams",
+		"nonrepeating",
 		"Norsk",
 		"nunjuck",
 		"odroid",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -55,11 +55,12 @@ const config = [
 			"@stylistic/semi": ["error", "always"],
 			"@stylistic/space-before-function-paren": ["error", "always"],
 			"@stylistic/spaced-comment": "off",
+			"dot-notation": "error",
 			eqeqeq: "error",
 			"id-length": "off",
-			"import/order": "error",
 			"import/extensions": "error",
 			"import/newline-after-import": "error",
+			"import/order": "error",
 			"init-declarations": "off",
 			"jest/consistent-test-it": "warn",
 			"jest/no-done-callback": "warn",
@@ -78,6 +79,7 @@ const config = [
 			"no-ternary": "off",
 			"no-throw-literal": "error",
 			"no-undefined": "off",
+			"no-unneeded-ternary": "error",
 			"no-unused-vars": "off",
 			"no-useless-return": "error",
 			"no-warning-comments": "off",
@@ -112,7 +114,8 @@ const config = [
 			"max-lines-per-function": ["error", 100],
 			"no-magic-numbers": "off",
 			"one-var": "off",
-			"prefer-destructuring": "off"
+			"prefer-destructuring": "off",
+			"sort-keys": "error"
 		}
 	},
 	{

--- a/js/app.js
+++ b/js/app.js
@@ -18,7 +18,7 @@ const fetch_timeout = process.env.mmFetchTimeout !== undefined ? process.env.mmF
 
 // Get version number.
 global.version = require(`${__dirname}/../package.json`).version;
-global.mmTestMode = process.env.mmTestMode === "true" ? true : false;
+global.mmTestMode = process.env.mmTestMode === "true";
 Log.log(`Starting MagicMirror: v${global.version}`);
 
 // Log system information.

--- a/js/electron.js
+++ b/js/electron.js
@@ -102,7 +102,7 @@ function createWindow () {
 	 */
 
 	let prefix;
-	if ((config["tls"] !== null && config["tls"]) || config.useHttps) {
+	if ((config.tls !== null && config.tls) || config.useHttps) {
 		prefix = "https://";
 	} else {
 		prefix = "http://";
@@ -151,11 +151,11 @@ function createWindow () {
 	//remove response headers that prevent sites of being embedded into iframes if configured
 	mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
 		let curHeaders = details.responseHeaders;
-		if (config["ignoreXOriginHeader"] || false) {
+		if (config.ignoreXOriginHeader || false) {
 			curHeaders = Object.fromEntries(Object.entries(curHeaders).filter((header) => !(/x-frame-options/i).test(header[0])));
 		}
 
-		if (config["ignoreContentSecurityPolicy"] || false) {
+		if (config.ignoreContentSecurityPolicy || false) {
 			curHeaders = Object.fromEntries(Object.entries(curHeaders).filter((header) => !(/content-security-policy/i).test(header[0])));
 		}
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -24,9 +24,9 @@ module.exports = {
 				versions: "kernel, node, npm, pm2"
 			});
 			let systemDataString = "System information:";
-			systemDataString += `\n### SYSTEM:   manufacturer: ${staticData["system"]["manufacturer"]}; model: ${staticData["system"]["model"]}; virtual: ${staticData["system"]["virtual"]}`;
-			systemDataString += `\n### OS:       platform: ${staticData["osInfo"]["platform"]}; distro: ${staticData["osInfo"]["distro"]}; release: ${staticData["osInfo"]["release"]}; arch: ${staticData["osInfo"]["arch"]}; kernel: ${staticData["versions"]["kernel"]}`;
-			systemDataString += `\n### VERSIONS: electron: ${process.versions.electron}; used node: ${staticData["versions"]["node"]}; installed node: ${installedNodeVersion}; npm: ${staticData["versions"]["npm"]}; pm2: ${staticData["versions"]["pm2"]}`;
+			systemDataString += `\n### SYSTEM:   manufacturer: ${staticData.system.manufacturer}; model: ${staticData.system.model}; virtual: ${staticData.system.virtual}`;
+			systemDataString += `\n### OS:       platform: ${staticData.osInfo.platform}; distro: ${staticData.osInfo.distro}; release: ${staticData.osInfo.release}; arch: ${staticData.osInfo.arch}; kernel: ${staticData.versions.kernel}`;
+			systemDataString += `\n### VERSIONS: electron: ${process.versions.electron}; used node: ${staticData.versions.node}; installed node: ${installedNodeVersion}; npm: ${staticData.versions.npm}; pm2: ${staticData.versions.pm2}`;
 			systemDataString += `\n### OTHER:    timeZone: ${Intl.DateTimeFormat().resolvedOptions().timeZone}; ELECTRON_ENABLE_GPU: ${process.env.ELECTRON_ENABLE_GPU}`;
 			Log.info(systemDataString);
 

--- a/modules/default/weather/providers/openmeteo.js
+++ b/modules/default/weather/providers/openmeteo.js
@@ -244,17 +244,17 @@ WeatherProvider.register("openmeteo", {
 			.add(Math.max(0, Math.min(7, this.config.maxNumberOfDays)), "days")
 			.endOf("day");
 
-		params["start_date"] = startDate.format("YYYY-MM-DD");
+		params.start_date = startDate.format("YYYY-MM-DD");
 
 		switch (this.config.type) {
 			case "hourly":
 			case "daily":
 			case "forecast":
-				params["end_date"] = endDate.format("YYYY-MM-DD");
+				params.end_date = endDate.format("YYYY-MM-DD");
 				break;
 			case "current":
-				params["current_weather"] = true;
-				params["end_date"] = params["start_date"];
+				params.current_weather = true;
+				params.end_date = params.start_date;
 				break;
 			default:
 				// Failsafe
@@ -262,7 +262,7 @@ WeatherProvider.register("openmeteo", {
 		}
 
 		return Object.keys(params)
-			.filter((key) => (params[key] ? true : false))
+			.filter((key) => (!!params[key]))
 			.map((key) => {
 				switch (key) {
 					case "hourly":

--- a/modules/default/weather/providers/openweathermap.js
+++ b/modules/default/weather/providers/openweathermap.js
@@ -285,12 +285,12 @@ WeatherProvider.register("openweathermap", {
 			current.weatherType = this.convertWeatherType(data.current.weather[0].icon);
 			current.humidity = data.current.humidity;
 			current.uv_index = data.current.uvi;
-			if (data.current.hasOwnProperty("rain") && !isNaN(data.current["rain"]["1h"])) {
-				current.rain = data.current["rain"]["1h"];
+			if (data.current.hasOwnProperty("rain") && !isNaN(data.current.rain["1h"])) {
+				current.rain = data.current.rain["1h"];
 				precip = true;
 			}
-			if (data.current.hasOwnProperty("snow") && !isNaN(data.current["snow"]["1h"])) {
-				current.snow = data.current["snow"]["1h"];
+			if (data.current.hasOwnProperty("snow") && !isNaN(data.current.snow["1h"])) {
+				current.snow = data.current.snow["1h"];
 				precip = true;
 			}
 			if (precip) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,10 +24,10 @@
 				"module-alias": "^2.2.3",
 				"moment": "^2.30.1",
 				"node-ical": "^0.20.1",
-				"pm2": "^5.4.2",
+				"pm2": "^5.4.3",
 				"socket.io": "^4.8.1",
 				"suncalc": "^1.9.0",
-				"systeminformation": "^5.23.23",
+				"systeminformation": "^5.23.24",
 				"undici": "^7.2.0"
 			},
 			"devDependencies": {
@@ -13084,9 +13084,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/systeminformation": {
-			"version": "5.23.23",
-			"resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.23.23.tgz",
-			"integrity": "sha512-QhEWrMFZnzWjFZ7J65gikIXTrB8U6b7VTQ8pLaF/GUgJaJoUoSuucqalIVj91D/grhRUtXplL6qYwTn1A4FfhQ==",
+			"version": "5.23.24",
+			"resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.23.24.tgz",
+			"integrity": "sha512-dPEaqxCaOQMp+5/zCSjuGWbYW2NNBHUZZgI8SNs8xZbLSML2gXvf8OUiqr7Ea1zLkEuH3Tu58DLiNe4kwftPxw==",
 			"license": "MIT",
 			"os": [
 				"darwin",

--- a/package.json
+++ b/package.json
@@ -76,10 +76,10 @@
 		"module-alias": "^2.2.3",
 		"moment": "^2.30.1",
 		"node-ical": "^0.20.1",
-		"pm2": "^5.4.2",
+		"pm2": "^5.4.3",
 		"socket.io": "^4.8.1",
 		"suncalc": "^1.9.0",
-		"systeminformation": "^5.23.23",
+		"systeminformation": "^5.23.24",
 		"undici": "^7.2.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Main point was to enable ESLint `dot-notation` and `no-unneeded-ternary` rules for more code consistency.

I took the occasion to add two minor commits:
- Fix a problem found by running `test:spelling
- Minor dependency update

It wouldn't be a problem if the PR didn't arrive in the next release, the changes are cosmetic.