### PR TITLE
clientonly and wayland, hotfix electron tests

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -34,7 +34,7 @@ jobs:
           npm run test:css
           npm run test:markdown
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ planned for 2025-04-01
 
 ### Changed
 
+- [core] starting clientonly now checks for needed env var `WAYLAND_DISPLAY` or `DISPLAY` and starts electron with needed parameters (if both are set wayland is used)
+
 ### Removed
 
 ### Updated

--- a/clientonly/index.js
+++ b/clientonly/index.js
@@ -83,6 +83,17 @@
 	if (["localhost", "127.0.0.1", "::1", "::ffff:127.0.0.1", undefined].indexOf(config.address) === -1) {
 		getServerConfig(`${prefix}${config.address}:${config.port}/config/`)
 			.then(function (configReturn) {
+				// check environment for DISPLAY or WAYLAND_DISPLAY
+				const elecParams = ["js/electron.js"];
+				if (process.env.WAYLAND_DISPLAY !== "") {
+					console.log(`Client: Using WAYLAND_DISPLAY=${process.env.WAYLAND_DISPLAY}`);
+					elecParams.push("--enable-features=UseOzonePlatform");
+					elecParams.push("--ozone-platform=wayland");
+				} else if (process.env.DISPLAY !== "") {
+					console.log(`Client: Using DISPLAY=${process.env.DISPLAY}`);
+				} else {
+					fail("Error: Requires environment variable WAYLAND_DISPLAY or DISPLAY, none is provided.");
+				}
 				// Pass along the server config via an environment variable
 				const env = Object.create(process.env);
 				env.clientonly = true; // set to pass to electron.js
@@ -94,7 +105,7 @@
 
 				// Spawn electron application
 				const electron = require("electron");
-				const child = require("node:child_process").spawn(electron, ["js/electron.js"], options);
+				const child = require("node:child_process").spawn(electron, elecParams, options);
 
 				// Pipe all child process output to current stdout
 				child.stdout.on("data", function (buf) {


### PR DESCRIPTION
clientonly:
- did work only with xserver and `DISPLAY` env var
- now checks for `WAYLAND_DISPLAY` or `DISPLAY` env var before running
- if `WAYLAND_DISPLAY` is set now starts with wayland parameters

electron tests see #3676 