### PR TITLE
Fix unknown (n/a) icon in openmeteo provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,10 @@ planned for 2025-04-01
 
 ### Fixed
 
-- [calendar] fix clipping events being broadcast (#3678)
+- [calendar] Fix clipping events being broadcast (#3678)
 - [tests] Electron tests: Fixes for running under new github image ubuntu-24.04, replace xserver with labwc (#3676)
-- [calendar] fix arrayed symbols, #3267, again, add testcase, add testcase for #3678
+- [calendar] Fix arrayed symbols, #3267, again, add testcase, add testcase for #3678
+- [weather] Fix wrong weatherCondition name in openmeteo provider which lead to n/a icon
 
 ## [2.30.0] - 2025-01-01
 

--- a/modules/default/weather/providers/openmeteo.js
+++ b/modules/default/weather/providers/openmeteo.js
@@ -470,7 +470,7 @@ WeatherProvider.register("openmeteo", {
 			61: "rain-slight-intensity",
 			63: "rain-moderate-intensity",
 			65: "rain-heavy-intensity",
-			66: "freezing-rain-light-heavy-intensity",
+			66: "freezing-rain-light-intensity",
 			67: "freezing-rain-heavy-intensity",
 			71: "snow-fall-slight-intensity",
 			73: "snow-fall-moderate-intensity",


### PR DESCRIPTION
Due to a typo the icon displayed in the openmeteo provider was "N/A" for a certain weather condition

<img width="284" alt="Bildschirmfoto 2025-01-13 um 16 35 40" src="https://github.com/user-attachments/assets/e64bf0f8-32d9-44a5-a2b0-42d4f2d6b6df" />
