### PR TITLE
update to electron v34

### DIFF
--- a/.github/workflows/electron-rebuild.yaml
+++ b/.github/workflows/electron-rebuild.yaml
@@ -25,6 +25,8 @@ jobs:
         run: sudo apt-get install gpiod libgpiod2 libgpiod-dev
       - name: Install test library (node-libgpiod) to be rebuilded
         run: npm install node-libgpiod
+      - name: Fix for nan and electron rebuild as long as https://github.com/nodejs/nan/pull/979 is not merged
+        run: sed -i 's|^#include .nan_scriptorigin\.h.*||g' ./node_modules/nan/nan.h
       - name: Run electron-rebuild
         run: npx electron-rebuild
         continue-on-error: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ planned for 2025-04-01
 
 ### Updated
 
-- [core] Update dependencies and formatting
+- [core] Update dependencies and formatting including electron to v34
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,13 +28,13 @@
 				"socket.io": "^4.8.1",
 				"suncalc": "^1.9.0",
 				"systeminformation": "^5.25.11",
-				"undici": "^7.2.1"
+				"undici": "^7.2.2"
 			},
 			"devDependencies": {
 				"@stylistic/eslint-plugin": "^2.13.0",
 				"cspell": "^8.17.2",
 				"eslint-plugin-import": "^2.31.0",
-				"eslint-plugin-jest": "^28.10.0",
+				"eslint-plugin-jest": "^28.11.0",
 				"eslint-plugin-jsdoc": "^50.6.1",
 				"eslint-plugin-package-json": "^0.19.0",
 				"express-basic-auth": "^1.2.1",
@@ -46,7 +46,7 @@
 				"playwright": "^1.49.1",
 				"prettier": "^3.4.2",
 				"sinon": "^19.0.2",
-				"stylelint": "^16.13.1",
+				"stylelint": "^16.13.2",
 				"stylelint-config-standard": "^37.0.0",
 				"stylelint-prettier": "^5.0.2"
 			},
@@ -54,7 +54,7 @@
 				"node": ">=20.18.1 <21 || >=22"
 			},
 			"optionalDependencies": {
-				"electron": "^32.2.8"
+				"electron": "^34.0.0"
 			}
 		},
 		"node_modules/@altano/repository-tools": {
@@ -79,9 +79,9 @@
 			}
 		},
 		"node_modules/@asamuzakjp/css-color": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-2.8.2.tgz",
-			"integrity": "sha512-RtWv9jFN2/bLExuZgFFZ0I3pWWeezAHGgrmjqGGWclATl1aDe3yhCUaI0Ilkp6OCk9zX7+FjvDasEX8Q9Rxc5w==",
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-2.8.3.tgz",
+			"integrity": "sha512-GIc76d9UI1hCvOATjZPyHFmE5qhRccp3/zGfMPapK3jBi+yocEzp6BBB0UnfRYP9NP4FANqUZYb0hnfs3TM3hw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -89,18 +89,15 @@
 				"@csstools/css-color-parser": "^3.0.7",
 				"@csstools/css-parser-algorithms": "^3.0.4",
 				"@csstools/css-tokenizer": "^3.0.3",
-				"lru-cache": "^11.0.2"
+				"lru-cache": "^10.4.3"
 			}
 		},
 		"node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-			"version": "11.0.2",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
-			"integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
 			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "20 || >=22"
-			}
+			"license": "ISC"
 		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.26.2",
@@ -1041,9 +1038,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-npm": {
-			"version": "5.1.22",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.22.tgz",
-			"integrity": "sha512-fZBTn8QHr8pAv1/I14CmdDWpVkovCfYpSYiGfV1SZkOjrsKLzPxsP84eaP3RijbFtYj3GMplVN27FR3H5oHfiw==",
+			"version": "5.1.23",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.23.tgz",
+			"integrity": "sha512-/xK7G1/H5M73J3CAb3WmVXlMbK6zjZrfwmOOBiB7SSbK6h7/WmwRBuLC0UwO50x07NJUuVmJek5ELaNa81guVw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1062,9 +1059,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-public-licenses": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.12.tgz",
-			"integrity": "sha512-obreJMVbz8ZrXyc60PcS/B2FwXaO3AWPO2x50zrI/n4UDuBr/UdPb6M1q++6c08n+151I35GEx52xRFiToSg4g==",
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.13.tgz",
+			"integrity": "sha512-1Wdp/XH1ieim7CadXYE7YLnUlW0pULEjVl9WEeziZw3EKCAw8ZI8Ih44m4bEa5VNBLnuP5TfqC4iDautAleQzQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2391,6 +2388,12 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/@pm2/io/node_modules/tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"license": "Apache-2.0"
+		},
 		"node_modules/@pm2/io/node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -2793,9 +2796,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "20.17.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.12.tgz",
-			"integrity": "sha512-vo/wmBgMIiEA23A/knMfn/cf37VnuF52nZh5ZoW0GWt4e4sxNquibrMRJ7UQsA06+MBx9r/H1jsI9grYjQCQlw==",
+			"version": "20.17.13",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.13.tgz",
+			"integrity": "sha512-RNf+4dEeV69PIvyp++4IKM2vnLXtmp/JovfeQm5P5+qpKb6wHoH7INywLdZ7z+gVX46kgBP/fwJJvZYaHxtdyw==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.19.2"
@@ -3278,12 +3281,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/ast-types/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD"
 		},
 		"node_modules/astral-regex": {
 			"version": "2.0.0",
@@ -5154,9 +5151,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron": {
-			"version": "32.2.8",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-32.2.8.tgz",
-			"integrity": "sha512-jaAgBeFKjH6Cd7CnG7XhApZtLz2ewUXLyf1rKh9D+eaFD5XCYQpH77PhmrT5u0IpSP6eSZoHpAQ0sMqOFsh6kA==",
+			"version": "34.0.0",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-34.0.0.tgz",
+			"integrity": "sha512-fpaPb0lifoUJ6UJa4Lk8/0B2Ku/xDZWdc1Gkj67jbygTCrvSon0qquju6Ltx1Kz23GRqqlIHXiy9EvrjpY7/Wg==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -5173,9 +5170,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.80",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.80.tgz",
-			"integrity": "sha512-LTrKpW0AqIuHwmlVNV+cjFYTnXtM9K37OGhpe0ZI10ScPSxqVSryZHIY3WnCS5NSYbBODRTZyhRMS2h5FAEqAw==",
+			"version": "1.5.82",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.82.tgz",
+			"integrity": "sha512-Zq16uk1hfQhyGx5GpwPAYDwddJuSGhtRhgOA2mCxANYaDT79nAeGnaXogMGng4KqLaJUVnOnuL0+TDop9nLOiA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -5488,9 +5485,9 @@
 			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-			"integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0"
@@ -5785,9 +5782,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jest": {
-			"version": "28.10.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.10.0.tgz",
-			"integrity": "sha512-hyMWUxkBH99HpXT3p8hc7REbEZK3D+nk8vHXGgpB+XXsi0gO4PxMSP+pjfUzb67GnV9yawV9a53eUmcde1CCZA==",
+			"version": "28.11.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.11.0.tgz",
+			"integrity": "sha512-QAfipLcNCWLVocVbZW8GimKn5p5iiMcgGbRzz8z/P5q7xw+cNEpYqyzFMtIF/ZgF2HLOyy+dYBut+DoYolvqig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7529,12 +7526,6 @@
 			"engines": {
 				"node": ">= 12"
 			}
-		},
-		"node_modules/ip-address/node_modules/sprintf-js": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/ip6": {
 			"version": "0.2.11",
@@ -11376,6 +11367,12 @@
 				"source-map": "^0.6.0"
 			}
 		},
+		"node_modules/pm2/node_modules/sprintf-js": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+			"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/possible-typed-array-names": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -11386,9 +11383,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.0.tgz",
-			"integrity": "sha512-27VKOqrYfPncKA2NrFOVhP5MGAfHKLYn/Q0mz9cNQyRAKYi3VNHwYU2qKKqPCqgBmeeJ0uAFB56NumXZ5ZReXg==",
+			"version": "8.5.1",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
+			"integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -12060,12 +12057,6 @@
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
-		},
-		"node_modules/rrule/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD"
 		},
 		"node_modules/rrweb-cssom": {
 			"version": "0.8.0",
@@ -12747,9 +12738,9 @@
 			"license": "MIT"
 		},
 		"node_modules/sort-package-json": {
-			"version": "2.13.0",
-			"resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-2.13.0.tgz",
-			"integrity": "sha512-y1iCgJ+ZrOSgkzuhtpaxxsCLeUPZbEbIxcMDBde6JwpkZ3e9vVQhZ46iCD97GYImdgBLtXSPxxS9LqZbL6Th2Q==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-2.14.0.tgz",
+			"integrity": "sha512-xBRdmMjFB/KW3l51mP31dhlaiFmqkHLfWTfZAno8prb/wbDxwBPWFpxB16GZbiPbYr3wL41H8Kx22QIDWRe8WQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -12838,16 +12829,16 @@
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.20",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz",
-			"integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
+			"version": "3.0.21",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
+			"integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/sprintf-js": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-			"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/stack-utils": {
@@ -13082,9 +13073,9 @@
 			}
 		},
 		"node_modules/stylelint": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.13.1.tgz",
-			"integrity": "sha512-691JjSIIcP6f9QJFz0J0/AMG3lupE9RqYAgYCON3wiqp5nQiKqDYIsz321GeTOYNznoRPNh0Mf6VjzP1eBVz/Q==",
+			"version": "16.13.2",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.13.2.tgz",
+			"integrity": "sha512-wDlgh0mRO9RtSa3TdidqHd0nOG8MmUyVKl+dxA6C1j8aZRzpNeEgdhFmU5y4sZx4Fc6r46p0fI7p1vR5O2DZqA==",
 			"dev": true,
 			"funding": [
 				{
@@ -13278,9 +13269,9 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/ignore": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.1.tgz",
-			"integrity": "sha512-D1gVletsbVOoiXF963rgZnfobGAbq7Lb+dz3fcBmlOmZg6hHkpbycLqL8PLNB8f4GVv6dOVYwhPL/r7hwiH0Fw==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.3.tgz",
+			"integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -13427,13 +13418,6 @@
 			"funding": {
 				"url": "https://opencollective.com/unts"
 			}
-		},
-		"node_modules/synckit/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"dev": true,
-			"license": "0BSD"
 		},
 		"node_modules/systeminformation": {
 			"version": "5.25.11",
@@ -13582,22 +13566,22 @@
 			}
 		},
 		"node_modules/tldts": {
-			"version": "6.1.71",
-			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.71.tgz",
-			"integrity": "sha512-LQIHmHnuzfZgZWAf2HzL83TIIrD8NhhI0DVxqo9/FdOd4ilec+NTNZOlDZf7EwrTNoutccbsHjvWHYXLAtvxjw==",
+			"version": "6.1.72",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.72.tgz",
+			"integrity": "sha512-QNtgIqSUb9o2CoUjX9T5TwaIvUUJFU1+12PJkgt42DFV2yf9J6549yTF2uGloQsJ/JOC8X+gIB81ind97hRiIQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^6.1.71"
+				"tldts-core": "^6.1.72"
 			},
 			"bin": {
 				"tldts": "bin/cli.js"
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "6.1.71",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.71.tgz",
-			"integrity": "sha512-LRbChn2YRpic1KxY+ldL1pGXN/oVvKfCVufwfVzEQdFYNo39uF7AJa/WXdo+gYO7PTvdfkCPCed6Hkvz/kR7jg==",
+			"version": "6.1.72",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.72.tgz",
+			"integrity": "sha512-FW3H9aCaGTJ8l8RVCR3EX8GxsxDbQXuwetwwgXA2chYdsX+NY1ytCBl61narjjehWmCw92tc1AxlcY3668CU8g==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -13705,10 +13689,10 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-			"license": "Apache-2.0"
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
 		},
 		"node_modules/tv4": {
 			"version": "1.3.0",
@@ -13914,9 +13898,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.2.1",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.2.1.tgz",
-			"integrity": "sha512-U2k0XHLJfaciARRxDcqTk2AZQsGXerHzdvfCZcy1hNhSf5KCAF4jIQQxL+apQviOekhRFPqED6Of5/+LcUSLzQ==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.2.2.tgz",
+			"integrity": "sha512-j/M0BQelSQHcq2Fhc1fUMszXtLx+RsZR5IkXx07knZMICLTzRzsW0tbTI9e9N40RftPUkFP8j4qOjKJa5aTCzw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -80,13 +80,13 @@
 		"socket.io": "^4.8.1",
 		"suncalc": "^1.9.0",
 		"systeminformation": "^5.25.11",
-		"undici": "^7.2.1"
+		"undici": "^7.2.2"
 	},
 	"devDependencies": {
 		"@stylistic/eslint-plugin": "^2.13.0",
 		"cspell": "^8.17.2",
 		"eslint-plugin-import": "^2.31.0",
-		"eslint-plugin-jest": "^28.10.0",
+		"eslint-plugin-jest": "^28.11.0",
 		"eslint-plugin-jsdoc": "^50.6.1",
 		"eslint-plugin-package-json": "^0.19.0",
 		"express-basic-auth": "^1.2.1",
@@ -98,12 +98,12 @@
 		"playwright": "^1.49.1",
 		"prettier": "^3.4.2",
 		"sinon": "^19.0.2",
-		"stylelint": "^16.13.1",
+		"stylelint": "^16.13.2",
 		"stylelint-config-standard": "^37.0.0",
 		"stylelint-prettier": "^5.0.2"
 	},
 	"optionalDependencies": {
-		"electron": "^32.2.8"
+		"electron": "^34.0.0"
 	},
 	"engines": {
 		"node": ">=20.18.1 <21 || >=22"


### PR DESCRIPTION
related to #3593 

- electron-rebuild fails in our tests with electron v33 and v34 because `nan` must be fixed
- there is an [open PR](https://github.com/nodejs/nan/pull/979) from Okt. 24 which is still unmerged
- comment from [this issue](https://github.com/nodejs/nan/issues/978): `You should not ping nan maintainers as they have been quick to point out that they do not support and have no intention to support Electron in the future.`
- in above issue a fix is mentioned to get nan running which I have included in this PR to get the tests running
- the currently used electron v32 has end of support 04 Mar 2025
- we don't have to merge this now, we can wait until March for a decision how to progress