### PR TITLE
Déplace l'affichage des informations système au démarrage du noyau (promesse)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ planned for 2025-04-01
 - [core] Optimize systeminformation calls and output (#3689)
 - [core] Add issue templates for feature requests and bug reports (#3695)
 - [core] Adapt `start:x11:dev` script
-- [core] Déplace l'affichage des informations système au démarrage du noyau (promesse) (#XXXX)
+- [core] Déplace l'affichage des informations système au démarrage du noyau (promesse) (#3703)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ planned for 2025-04-01
 - [core] Optimize systeminformation calls and output (#3689)
 - [core] Add issue templates for feature requests and bug reports (#3695)
 - [core] Adapt `start:x11:dev` script
+- [core] Déplace l'affichage des informations système au démarrage du noyau (promesse) (#XXXX)
 
 ### Removed
 

--- a/js/app.js
+++ b/js/app.js
@@ -21,9 +21,6 @@ global.version = require(`${__dirname}/../package.json`).version;
 global.mmTestMode = process.env.mmTestMode === "true";
 Log.log(`Starting MagicMirror: v${global.version}`);
 
-// Log system information.
-Utils.logSystemInformation();
-
 // global absolute root path
 global.root_path = path.resolve(`${__dirname}/../`);
 
@@ -276,6 +273,9 @@ function App () {
 	 * @returns {Promise<object>} the config used
 	 */
 	this.start = async function () {
+		// Log system information.
+		await Utils.logSystemInformation();
+
 		config = await loadConfig();
 
 		Log.setLogLevel(config.logLevel);


### PR DESCRIPTION
Je me permet de proposer cette petite modification qui permet d'avoir directement les informations système juste apres la confirmation du démarrage de MM²

Actuellement, le scan sysinfo est demandé sans promesse donc il se charge en meme temps que le core
c'est peut-etre pour cela que nous avons des timeout (avec fetch) lors des chargements des modules.
Le sysinfo s'affiche donc longtemps apres, lors du chargement de MM².

J'ai donc déplacer l'affichage du sysinfo en promesse afin de garantir qu'il soit afficher au démarrage et avoir une visibilité parfaite.

```sh
[2025-01-24 12:51:18.549] [LOG]   Starting MagicMirror: v2.31.0-develop 
[2025-01-24 12:51:18.823] [INFO]  System information:
### SYSTEM:   manufacturer: XXX; model: XXXXX; virtual: false
### OS:       platform: linux; distro: Ubuntu; release: 24.10; arch: x64; kernel: 6.11.0-13-generic
### VERSIONS: electron: 32.2.8; used node: 23.6.0; installed node: 23.6.0; npm: 10.9.2; pm2: 5.4.3
### OTHER:    timeZone: Europe/Paris; ELECTRON_ENABLE_GPU: undefined 
[2025-01-24 12:51:18.823] [LOG]   Loading config ... 
```

Que pensez-vous de ceci ?

----
(@sdetweil s'occupera de traduire si besoin)