### PR TITLE
update github workflows

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -41,7 +41,9 @@ jobs:
         node-version: [20.18.1, 20.x, 22.x, 23.x]
     steps:
       - name: Install electron dependencies and labwc
-        run: sudo apt-get install -y libnss3 libasound2t64 labwc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libnss3 libasound2t64 labwc
       - name: "Checkout code"
         uses: actions/checkout@v4
       - name: "Use Node.js ${{ matrix.node-version }}"

--- a/.github/workflows/electron-rebuild.yaml
+++ b/.github/workflows/electron-rebuild.yaml
@@ -22,7 +22,9 @@ jobs:
       - name: Install @electron/rebuild
         run: npm install @electron/rebuild
       - name: Install node-libgpiod deps
-        run: sudo apt-get install gpiod libgpiod2 libgpiod-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install gpiod libgpiod2 libgpiod-dev
       - name: Install test library (node-libgpiod) to be rebuilded
         run: npm install node-libgpiod
       - name: Run electron-rebuild

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ planned for 2025-04-01
 - [core] Add issue templates for feature requests and bug reports (#3695)
 - [core] Adapt `start:x11:dev` script
 - [weather/yr] The Yr weather provider now enforces a minimum `updateInterval` of 600 000 ms (10 minutes) to comply with the terms of service. If a lower value is set, it will be automatically increased to this minimum.
+- [workflow] Run `sudo apt-get update` before installing packages to avoid install errors
 
 ### Removed
 


### PR DESCRIPTION
 to call `sudo apt-get update` before `sudo apt-get install`

I had problems running the tests on my fork, while running the `apt-get install` command in automated tests workflow I got

```bash
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/m/mesa/libegl-mesa0_24.0.9-0ubuntu0.3_amd64.deb  404  Not Found [IP: 52.147.219.192 80]
```

Found a similar [Issue](https://github.com/actions/runner-images/issues/10785#issuecomment-2420741561) with a solution which is to run `sudo apt-get update` before.