### PR TITLE
set name and path in module init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ planned for 2025-04-01
 - [core] Fix wrong port in log message when starting server only (#3696)
 - [calendar] NewYork event processed on system in Central timezone shows wrong time #3701
 - [weather/yr] The Yr weather provider is now able to recover from bad API resposes instead of freezing (#3296)
+- [core] Add missing name and path to node_helper init function (#3708)
 
 ## [2.30.0] - 2025-01-01
 

--- a/js/app.js
+++ b/js/app.js
@@ -210,7 +210,7 @@ function App () {
 				Log.error(`Error when loading ${moduleName}:`, e.message);
 				return;
 			}
-			let m = new Module();
+			let m = new Module(moduleName, path.resolve(moduleFolder));
 
 			if (m.requiresVersion) {
 				Log.log(`Check MagicMirror² version for node helper '${moduleName}' - Minimum version: ${m.requiresVersion} - Current version: ${global.version}`);
@@ -222,8 +222,6 @@ function App () {
 				}
 			}
 
-			m.setName(moduleName);
-			m.setPath(path.resolve(moduleFolder));
 			nodeHelpers.push(m);
 
 			m.loaded();

--- a/js/node_helper.js
+++ b/js/node_helper.js
@@ -3,8 +3,11 @@ const Log = require("logger");
 const Class = require("./class");
 
 const NodeHelper = Class.extend({
-	init () {
-		Log.log("Initializing new module helper ...");
+	init (name, path) {
+		this.setName(name);
+		this.setPath(path);
+
+		Log.log(`Initializing new module helper: ${this.name}`);
 	},
 
 	loaded () {


### PR DESCRIPTION
This is a solution for #3708 

I set it to draft because I'm not sure if it should be merged.

With this change the `this.name` will now work in the `init` function but for get this working in a module you have to copy the content of the node_helper `init` into your module. This is nothing new, you have to do the same for e.g. `start`.

AFAIS the used construction in `js/class.js` misses inheritence for this.