### PR TITLE
update required node version and dependencies

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version: [20.18.1, 20.x, 22.x, 23.x]
+        node-version: [22.14.0, 22.x, 23.x]
     steps:
       - name: Install electron dependencies and labwc
         run: |

--- a/.github/workflows/electron-rebuild.yaml
+++ b/.github/workflows/electron-rebuild.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.18.1, 20.x, 22.x, 23.x]
+        node-version: [22.14.0, 22.x, 23.x]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 planned for 2025-04-01
 
-> ⚠️ This release needs nodejs version `v20` or `v22 or higher`, minimum version is `v20.18.1`
+> ⚠️ This release needs nodejs version `v22.14.0 or higher`
 
 ### Added
 
@@ -35,7 +35,7 @@ planned for 2025-04-01
 
 ### Updated
 
-- [core] Update dependencies incl. electron to v35 and formatting (#3593, #3693, #3717)
+- [core] Update requirements and dependencies incl. electron to v35 and formatting (#3593, #3693, #3717)
 - [core] Update prettier, ESLint and simplify config
 - Update Greek translation
 

--- a/Collaboration.md
+++ b/Collaboration.md
@@ -34,7 +34,7 @@ Are done by
 - [ ] test `develop` branch
 - [ ] update `CHANGELOG.md`
   - [ ] add all contributor names: `...`
-  - [ ] add min. node version: > ⚠️ This release needs nodejs version `v20` or `v22`, minimum version is `v20.9.0`
+  - [ ] add min. node version: > ⚠️ This release needs nodejs version `v22.14.0` or higher
   - [ ] check release link at the bottom of the file
 - [ ] commit and push all changes
 - [ ] after successful test run via github actions: merge pull request to `develop`

--- a/fonts/package-lock.json
+++ b/fonts/package-lock.json
@@ -9,21 +9,27 @@
 			"version": "1.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"@fontsource/roboto": "^5.2.0",
-				"@fontsource/roboto-condensed": "^5.2.0"
+				"@fontsource/roboto": "^5.2.5",
+				"@fontsource/roboto-condensed": "^5.2.5"
 			}
 		},
 		"node_modules/@fontsource/roboto": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.2.0.tgz",
-			"integrity": "sha512-RgDVfXtRZlMRBkzcVMETP0m5Xy8VaKAEnqTD2NFe34B6Qc2Xvn01Hxu3mdrF2My0YM0n4Iae5XWM7yzEsm4OZg==",
-			"license": "OFL-1.1"
+			"version": "5.2.5",
+			"resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.2.5.tgz",
+			"integrity": "sha512-70r2UZ0raqLn5W+sPeKhqlf8wGvUXFWlofaDlcbt/S3d06+17gXKr3VNqDODB0I1ASme3dGT5OJj9NABt7OTZQ==",
+			"license": "OFL-1.1",
+			"funding": {
+				"url": "https://github.com/sponsors/ayuhito"
+			}
 		},
 		"node_modules/@fontsource/roboto-condensed": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@fontsource/roboto-condensed/-/roboto-condensed-5.2.0.tgz",
-			"integrity": "sha512-j4e8QCvz4J14nVYONSZI8X7M9uiMH8vxt3DT37IendV8FTtSvwvvok1oTpRXrWT0YHQ0mUTbl2XUmBsCTiX4Lg==",
-			"license": "OFL-1.1"
+			"version": "5.2.5",
+			"resolved": "https://registry.npmjs.org/@fontsource/roboto-condensed/-/roboto-condensed-5.2.5.tgz",
+			"integrity": "sha512-FVubmVJpZ2js2+nCBEA3IOHhAgWmZ2/YKvTae0X25jlxbd85umOOvUIY6FL6OMpUvIgvwOImS9l0GJjzEPk+mg==",
+			"license": "OFL-1.1",
+			"funding": {
+				"url": "https://github.com/sponsors/ayuhito"
+			}
 		}
 	}
 }

--- a/fonts/package.json
+++ b/fonts/package.json
@@ -11,7 +11,7 @@
 	},
 	"license": "MIT",
 	"dependencies": {
-		"@fontsource/roboto": "^5.2.0",
-		"@fontsource/roboto-condensed": "^5.2.0"
+		"@fontsource/roboto": "^5.2.5",
+		"@fontsource/roboto-condensed": "^5.2.5"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
 				"stylelint-prettier": "^5.0.3"
 			},
 			"engines": {
-				"node": ">=20.18.1 <21 || >=22"
+				"node": ">=22.14.0"
 			},
 			"optionalDependencies": {
 				"electron": "^35.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,14 @@
 			"license": "MIT",
 			"dependencies": {
 				"ajv": "^8.17.1",
-				"ansis": "^3.16.0",
+				"ansis": "^3.17.0",
 				"console-stamp": "^3.1.2",
 				"envsub": "^4.1.0",
 				"eslint": "^9.22.0",
 				"express": "^4.21.2",
 				"express-ipfilter": "^1.3.2",
 				"feedme": "^2.0.2",
-				"helmet": "^8.0.0",
+				"helmet": "^8.1.0",
 				"html-to-text": "^9.0.5",
 				"iconv-lite": "^0.6.3",
 				"module-alias": "^2.2.3",
@@ -28,7 +28,7 @@
 				"socket.io": "^4.8.1",
 				"suncalc": "^1.9.0",
 				"systeminformation": "^5.25.11",
-				"undici": "^7.4.0"
+				"undici": "^7.5.0"
 			},
 			"devDependencies": {
 				"@stylistic/eslint-plugin": "^4.2.0",
@@ -41,11 +41,11 @@
 				"husky": "^9.1.7",
 				"jest": "^29.7.0",
 				"jsdom": "^26.0.0",
-				"lint-staged": "^15.4.3",
+				"lint-staged": "^15.5.0",
 				"markdownlint-cli2": "^0.17.2",
-				"playwright": "^1.50.1",
+				"playwright": "^1.51.1",
 				"prettier": "^3.5.3",
-				"sinon": "^19.0.2",
+				"sinon": "^19.0.4",
 				"stylelint": "^16.16.0",
 				"stylelint-config-standard": "^37.0.0",
 				"stylelint-prettier": "^5.0.3"
@@ -54,7 +54,7 @@
 				"node": ">=22.14.0"
 			},
 			"optionalDependencies": {
-				"electron": "^35.0.0"
+				"electron": "^35.0.3"
 			}
 		},
 		"node_modules/@altano/repository-tools": {
@@ -850,9 +850,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-en_us": {
-			"version": "4.3.34",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.34.tgz",
-			"integrity": "sha512-ewJXNV7Nk5vxbGvHvxYLDGoXN0Lq5sfSgX8SAlcYL+2bZ7r25nNOLHou5hdFlNgvviGTx/SFPlVKjdjVJlblgA==",
+			"version": "4.3.35",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.35.tgz",
+			"integrity": "sha512-HF6QNyPHkxeo/SosaZXRQlnKDUTjIzrGKyqfbw/fPPlPYrXefAZZ40ofheb5HnbUicR7xqV/lsc/HQfqYshGIw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1038,9 +1038,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-npm": {
-			"version": "5.1.30",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.30.tgz",
-			"integrity": "sha512-qRMJZFz4FBPECH5rGQN9p2Ld6nfpSaPFQvlG6V2RowWcrJQqF4RFmLUNuRQpvndpSeIUo32yX1hxb7AT45ARCQ==",
+			"version": "5.1.31",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.31.tgz",
+			"integrity": "sha512-Oh9nrhgNV4UD1hlbgO3TFQqQRKziwc7qXKoQiC4oqOYIhMs2WL9Ezozku7FY1e7o5XbCIZX9nRH0ymNx/Rwj6w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2196,9 +2196,9 @@
 			}
 		},
 		"node_modules/@pkgr/core": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
-			"integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.2.tgz",
+			"integrity": "sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2853,14 +2853,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.26.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.26.1.tgz",
-			"integrity": "sha512-6EIvbE5cNER8sqBu6V7+KeMZIC1664d2Yjt+B9EWUXrsyWpxx4lEZrmvxgSKRC6gX+efDL/UY9OpPZ267io3mg==",
+			"version": "8.27.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.27.0.tgz",
+			"integrity": "sha512-8oI9GwPMQmBryaaxG1tOZdxXVeMDte6NyJA4i7/TWa4fBwgnAXYlIQP+uYOeqAaLJ2JRxlG9CAyL+C+YE9Xknw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.26.1",
-				"@typescript-eslint/visitor-keys": "8.26.1"
+				"@typescript-eslint/types": "8.27.0",
+				"@typescript-eslint/visitor-keys": "8.27.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2871,9 +2871,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.26.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.26.1.tgz",
-			"integrity": "sha512-n4THUQW27VmQMx+3P+B0Yptl7ydfceUj4ON/AQILAASwgYdZ/2dhfymRMh5egRUrvK5lSmaOm77Ry+lmXPOgBQ==",
+			"version": "8.27.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.27.0.tgz",
+			"integrity": "sha512-/6cp9yL72yUHAYq9g6DsAU+vVfvQmd1a8KyA81uvfDE21O2DwQ/qxlM4AR8TSdAu+kJLBDrEHKC5/W2/nxsY0A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2885,14 +2885,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.26.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.26.1.tgz",
-			"integrity": "sha512-yUwPpUHDgdrv1QJ7YQal3cMVBGWfnuCdKbXw1yyjArax3353rEJP1ZA+4F8nOlQ3RfS2hUN/wze3nlY+ZOhvoA==",
+			"version": "8.27.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.27.0.tgz",
+			"integrity": "sha512-BnKq8cqPVoMw71O38a1tEb6iebEgGA80icSxW7g+kndx0o6ot6696HjG7NdgfuAVmVEtwXUr3L8R9ZuVjoQL6A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.26.1",
-				"@typescript-eslint/visitor-keys": "8.26.1",
+				"@typescript-eslint/types": "8.27.0",
+				"@typescript-eslint/visitor-keys": "8.27.0",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -2912,16 +2912,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.26.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.26.1.tgz",
-			"integrity": "sha512-V4Urxa/XtSUroUrnI7q6yUTD3hDtfJ2jzVfeT3VK0ciizfK2q/zGC0iDh1lFMUZR8cImRrep6/q0xd/1ZGPQpg==",
+			"version": "8.27.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.27.0.tgz",
+			"integrity": "sha512-njkodcwH1yvmo31YWgRHNb/x1Xhhq4/m81PhtvmRngD8iHPehxffz1SNCO+kwaePhATC+kOa/ggmvPoPza5i0Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
-				"@typescript-eslint/scope-manager": "8.26.1",
-				"@typescript-eslint/types": "8.26.1",
-				"@typescript-eslint/typescript-estree": "8.26.1"
+				"@typescript-eslint/scope-manager": "8.27.0",
+				"@typescript-eslint/types": "8.27.0",
+				"@typescript-eslint/typescript-estree": "8.27.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2936,13 +2936,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.26.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.26.1.tgz",
-			"integrity": "sha512-AjOC3zfnxd6S4Eiy3jwktJPclqhFHNyd8L6Gycf9WUPoKZpgM5PjkxY1X7uSy61xVpiJDhhk7XT2NVsN3ALTWg==",
+			"version": "8.27.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.27.0.tgz",
+			"integrity": "sha512-WsXQwMkILJvffP6z4U3FYJPlbf/j07HIxmDjZpbNvBJkMfvwXj5ACRkkHwBDvLBbDbtX5TdU64/rcvKJ/vuInQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.26.1",
+				"@typescript-eslint/types": "8.27.0",
 				"eslint-visitor-keys": "^4.2.0"
 			},
 			"engines": {
@@ -3333,9 +3333,9 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
-			"integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
+			"version": "1.8.4",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+			"integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.6",
@@ -5164,9 +5164,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron": {
-			"version": "35.0.2",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-35.0.2.tgz",
-			"integrity": "sha512-jo8S4GfBpVIBDGitUrv+Vo/I/ZEEs6IvWprG2KJlxayYIKpufulbQaxDt78cC/79FwFo8MA0JOIwx/b9r5NRag==",
+			"version": "35.0.3",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-35.0.3.tgz",
+			"integrity": "sha512-kjQAYEWXSr2TyK19IZoF85dzFIBaYuX7Yp/C+34b5Y/jmI2z270CGie+RjmEGMMitsy0G8YJKftukhYMuWlK6g==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -5183,9 +5183,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.120",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.120.tgz",
-			"integrity": "sha512-oTUp3gfX1gZI+xfD2djr2rzQdHCwHzPQrrK0CD7WpTdF0nPdQ/INcRVjWgLdCT4a9W3jFObR9DAfsuyFQnI8CQ==",
+			"version": "1.5.123",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.123.tgz",
+			"integrity": "sha512-refir3NlutEZqlKaBLK0tzlVLe5P2wDKS7UQt/3SpibizgsRAPOsqQC3ffw1nlv3ze5gjRQZYHoPymgVZkplFA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -10414,9 +10414,9 @@
 			"license": "ISC"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.10",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.10.tgz",
-			"integrity": "sha512-vSJJTG+t/dIKAUhUDw/dLdZ9s//5OxcHqLaDWWrW4Cdq7o6tdLIczUkMXt2MBNmk6sJRZBZRXVixs7URY1CmIg==",
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
 			"dev": true,
 			"funding": [
 				{
@@ -12515,14 +12515,14 @@
 			"license": "ISC"
 		},
 		"node_modules/sinon": {
-			"version": "19.0.2",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
-			"integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
+			"version": "19.0.4",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.4.tgz",
+			"integrity": "sha512-myidFob7fjmYHJb+CHNLtAYScxn3sngGq4t75L2rCGGpE/k4OQVkN3KE5FsN+XkO2+fcDZ65PGvq3KHrlLAm7g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@sinonjs/commons": "^3.0.1",
-				"@sinonjs/fake-timers": "^13.0.2",
+				"@sinonjs/fake-timers": "^13.0.5",
 				"@sinonjs/samsam": "^8.0.1",
 				"diff": "^7.0.0",
 				"nise": "^6.1.1",
@@ -13678,9 +13678,9 @@
 			}
 		},
 		"node_modules/ts-api-utils": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
-			"integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+			"integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
 		"electron": "^35.0.0"
 	},
 	"engines": {
-		"node": ">=20.18.1 <21 || >=22"
+		"node": ">=22.14.0"
 	},
 	"_moduleAliases": {
 		"node_helper": "js/node_helper.js",

--- a/package.json
+++ b/package.json
@@ -63,14 +63,14 @@
 	},
 	"dependencies": {
 		"ajv": "^8.17.1",
-		"ansis": "^3.16.0",
+		"ansis": "^3.17.0",
 		"console-stamp": "^3.1.2",
 		"envsub": "^4.1.0",
 		"eslint": "^9.22.0",
 		"express": "^4.21.2",
 		"express-ipfilter": "^1.3.2",
 		"feedme": "^2.0.2",
-		"helmet": "^8.0.0",
+		"helmet": "^8.1.0",
 		"html-to-text": "^9.0.5",
 		"iconv-lite": "^0.6.3",
 		"module-alias": "^2.2.3",
@@ -80,7 +80,7 @@
 		"socket.io": "^4.8.1",
 		"suncalc": "^1.9.0",
 		"systeminformation": "^5.25.11",
-		"undici": "^7.4.0"
+		"undici": "^7.5.0"
 	},
 	"devDependencies": {
 		"@stylistic/eslint-plugin": "^4.2.0",
@@ -93,17 +93,17 @@
 		"husky": "^9.1.7",
 		"jest": "^29.7.0",
 		"jsdom": "^26.0.0",
-		"lint-staged": "^15.4.3",
+		"lint-staged": "^15.5.0",
 		"markdownlint-cli2": "^0.17.2",
-		"playwright": "^1.50.1",
+		"playwright": "^1.51.1",
 		"prettier": "^3.5.3",
-		"sinon": "^19.0.2",
+		"sinon": "^19.0.4",
 		"stylelint": "^16.16.0",
 		"stylelint-config-standard": "^37.0.0",
 		"stylelint-prettier": "^5.0.3"
 	},
 	"optionalDependencies": {
-		"electron": "^35.0.0"
+		"electron": "^35.0.3"
 	},
 	"engines": {
 		"node": ">=22.14.0"


### PR DESCRIPTION
see discussion in https://github.com/MagicMirrorOrg/MagicMirror/pull/3746

As [electron v35 requires node js v22.14.0](https://www.electronjs.org/blog/electron-35-0) we should update this here too.