### PR TITLE
[weather] add humidity to hourly view, fix spacing error when using UV Index, add config option to hide precipitation entries that are zero [Rebased Version of PR #3526]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ planned for 2025-04-01
 - Mark option `secondsColor` as deprecated in clock module.
 - Add Greek translation to Alerts module.
 - [newsfeed] Add specific ignoreOlderThan value (override) per feed (#3360)
+- [weather] Added option Humidity to hourly View
+- [weather] Added option to hide hourly entries that are Zero, hiding the entire column if empty.
 
 ### Changed
 
@@ -49,6 +51,7 @@ planned for 2025-04-01
 - [calendar] Fix NewYork event processed on system in Central timezone shows wrong time #3701
 - [weather/yr] The Yr weather provider is now able to recover from bad API responses instead of freezing (#3296)
 - [compliments] Fix evening events being shown during the day (#3727)
+- [weather] Fixed minor spacing issues when using UV Index in Hourly
 
 ## [2.30.0] - 2025-01-01
 

--- a/modules/default/weather/hourly.njk
+++ b/modules/default/weather/hourly.njk
@@ -28,14 +28,14 @@
                   </td>
                 {% endif %}
                 {% if config.showPrecipitationAmount %}
-                  {% if (!config.hideZeroes or hour.precipitationAmount>0) %}
+                  {% if (not config.hideZeroes or hour.precipitationAmount>0) %}
                       <td class="align-right bright precipitation-amount">
                           {{ hour.precipitationAmount | unit("precip", hour.precipitationUnits) }}
                       </td>
                   {% endif %}
                 {% endif %}
                 {% if config.showPrecipitationProbability %}
-                  {% if (!config.hideZeroes or hour.precipitationAmount>0) %}
+                  {% if (not config.hideZeroes or hour.precipitationAmount>0) %}
                     <td class="align-right bright precipitation-prob">
                       {{ hour.precipitationProbability | unit('precip', '%') }}
                     </td>

--- a/modules/default/weather/hourly.njk
+++ b/modules/default/weather/hourly.njk
@@ -21,15 +21,25 @@
                         {% endif %}
                     </td>
                 {% endif %}
+                {% if config.showHumidity != "none" %}
+                  <td class="align-left bright humidity-hourly">
+                          {{ hour.humidity }}
+                          <span class="wi wi-humidity humidity-icon"></span>
+                  </td>
+                {% endif %}
                 {% if config.showPrecipitationAmount %}
-                    <td class="align-right bright precipitation-amount">
-                        {{ hour.precipitationAmount | unit("precip", hour.precipitationUnits) }}
-                    </td>
+                  {% if (!config.hideZeroes or hour.precipitationAmount>0) %}
+                      <td class="align-right bright precipitation-amount">
+                          {{ hour.precipitationAmount | unit("precip", hour.precipitationUnits) }}
+                      </td>
+                  {% endif %}
                 {% endif %}
                 {% if config.showPrecipitationProbability %}
+                  {% if (!config.hideZeroes or hour.precipitationAmount>0) %}
                     <td class="align-right bright precipitation-prob">
-                        {{ hour.precipitationProbability | unit('precip', '%') }}
+                      {{ hour.precipitationProbability | unit('precip', '%') }}
                     </td>
+                  {% endif %}
                 {% endif %}
             </tr>
             {% set currentStep = currentStep + 1 %}

--- a/modules/default/weather/weather.css
+++ b/modules/default/weather/weather.css
@@ -31,6 +31,7 @@
 
 .weather .precipitation-amount,
 .weather .precipitation-prob,
+.weather .humidity-hourly,
 .weather .uv-index {
   padding-left: 20px;
   padding-right: 0;

--- a/modules/default/weather/weather.js
+++ b/modules/default/weather/weather.js
@@ -14,7 +14,8 @@ Module.register("weather", {
 		updateInterval: 10 * 60 * 1000, // every 10 minutes
 		animationSpeed: 1000,
 		showFeelsLike: true,
-		showHumidity: "none", // this is now a string; see current.njk
+		showHumidity: "none", // for current possible options are "none", "wind", "temp", "feelslike" or "below", for hourly "none" or "true"
+		hideZeroes: false, // hide zeroes (and empty columns) in hourly, currently only for precipitation
 		showIndoorHumidity: false,
 		showIndoorTemperature: false,
 		allowOverrideNotification: false,

--- a/modules/default/weather/weather.js
+++ b/modules/default/weather/weather.js
@@ -14,7 +14,7 @@ Module.register("weather", {
 		updateInterval: 10 * 60 * 1000, // every 10 minutes
 		animationSpeed: 1000,
 		showFeelsLike: true,
-		showHumidity: "none", // for current possible options are "none", "wind", "temp", "feelslike" or "below", for hourly "none" or "true"
+		showHumidity: "none", // possible options for "current" weather are "none", "wind", "temp", "feelslike" or "below", for "hourly" weather "none" or "true"
 		hideZeroes: false, // hide zeroes (and empty columns) in hourly, currently only for precipitation
 		showIndoorHumidity: false,
 		showIndoorTemperature: false,


### PR DESCRIPTION
Fixed Version of PR #3526 since that was against the wrong branch and had issues.

Original PR Text: 
Basically the title. Just some existing weather data included into hourly, some config option ("hideZeroes") to hide precipitation when it is zero (this actually shrinks the entire table, removing columns that are completely empty), and add a spacing column to fix the UV Index column.