### PR TITLE
[workflow] Use LTS node version and split "Run test" step

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: "Use Node.js"
         uses: actions/setup-node@v4
         with:
-          node-version: 23
+          node-version: lts/*
           cache: "npm"
       - name: "Install dependencies"
         run: |
@@ -55,7 +55,7 @@ jobs:
       - name: "Install MagicMirror²"
         run: |
           node --run install-mm:dev
-      - name: "Run tests"
+      - name: "Prepare environment for tests"
         run: |
           # Fix chrome-sandbox permissions:
           sudo chown root:root ./node_modules/electron/dist/chrome-sandbox
@@ -64,4 +64,6 @@ jobs:
           WLR_BACKENDS=headless WLR_LIBINPUT_NO_DEVICES=1 WLR_RENDERER=pixman labwc &
           export WAYLAND_DISPLAY=wayland-0
           touch css/custom.css
+      - name: "Run tests"
+        run: |
           node --run test

--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -62,8 +62,8 @@ jobs:
           sudo chmod 4755 ./node_modules/electron/dist/chrome-sandbox
           # Start labwc
           WLR_BACKENDS=headless WLR_LIBINPUT_NO_DEVICES=1 WLR_RENDERER=pixman labwc &
-          export WAYLAND_DISPLAY=wayland-0
           touch css/custom.css
       - name: "Run tests"
         run: |
+          export WAYLAND_DISPLAY=wayland-0
           node --run test

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: lts/*
           check-latest: true
           cache: "npm"
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ planned for 2025-07-01
 ### Changed
 
 - [refactor] Simplify module loading process (#3766)
-- Use "node --run" instead of "npm run" (#1511)
+- Use "node --run" instead of "npm run" (#3764)
+- [workflow] Run linter und spellcheck with LTS node version (#3767)
+- [workflow] Split "Run test" step into two steps for more clarity (#3767)
 
 ## [2.31.0] - 2025-04-01
 


### PR DESCRIPTION
Two small changes to the workflows:

- Run linter and spellcheck workflows with LTS node version. The advantage of this is that we no longer have to raise the node version for them.
- Split "Run test" step into two steps for more clarity.