### PR TITLE
[fix] Fix `start:dev` script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,12 @@ planned for 2025-07-01
 
 ### Added
 
-- [clock] Added option 'disableNextEvent' to hide next sun event.
+- [clock] Added option 'disableNextEvent' to hide next sun event (#3769)
 
 ### Changed
 
 - [refactor] Simplify module loading process (#3766)
-- Use "node --run" instead of "npm run" (#3764)
+- Use `node --run` instead of `npm run` (#3764) and adapt `start:dev` script.
 - [workflow] Run linter und spellcheck with LTS node version (#3767)
 - [workflow] Split "Run test" step into two steps for more clarity (#3767)
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"prepare": "[ -f node_modules/.bin/husky ] && husky || echo no husky installed.",
 		"server": "node ./serveronly",
 		"start": "node --run start:x11",
-		"start:dev": "node --run start -- dev",
+		"start:dev": "node --run start:x11 -- dev",
 		"start:wayland": "WAYLAND_DISPLAY=\"${WAYLAND_DISPLAY:=wayland-1}\" ./node_modules/.bin/electron js/electron.js --enable-features=UseOzonePlatform --ozone-platform=wayland",
 		"start:wayland:dev": "node --run start:wayland -- dev",
 		"start:windows": ".\\node_modules\\.bin\\electron js\\electron.js",


### PR DESCRIPTION
This will fix #3772 caused by #3764.

Since I work with `start:wayland:dev` instead of `start:dev`, I didn't notice this, sorry.