### PR TITLE
[refactor] Replace deprecated constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,17 +30,18 @@ planned for 2025-07-01
   - Replace `eslint-plugin-import` with `eslint-plugin-import-x`
   - Switch Stylelint config to flat format and simplify Stylelint scripts
 - [workflow] Replace Node.js version v23 with v24 (#3770)
+- [refactor] Replace deprecated constants
 
 ### Fixed
 
 - [fix] Handle spellcheck issues (#3783)
 - [calendar] fix fullday event rrule until with timezone offset (#3781)
 - [feat] Add rule `no-undef` in config file validation to fix #3785 (#3786)
-- [fonts] Fix `roboto.css` to avoid error message `Unknown descriptor 'var(' in @font-face rule.` in firefox console
+- [fonts] Fix `roboto.css` to avoid error message `Unknown descriptor 'var(' in @font-face rule.` in firefox console (#3787)
 
 ### Updated
 
-- [core] Update dependencies incl. electron to v36 (#3774)
+- [core] Update dependencies incl. electron to v36 (#3774, #3788)
 
 ## [2.31.0] - 2025-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ planned for 2025-07-01
   - Replace `eslint-plugin-import` with `eslint-plugin-import-x`
   - Switch Stylelint config to flat format and simplify Stylelint scripts
 - [workflow] Replace Node.js version v23 with v24 (#3770)
-- [refactor] Replace deprecated constants
+- [refactor] Replace deprecated constants `fs.F_OK` and `fs.R_OK` (#3789)
 
 ### Fixed
 

--- a/js/app.js
+++ b/js/app.js
@@ -77,7 +77,7 @@ function App () {
 
 		// check if templateFile exists
 		try {
-			fs.accessSync(templateFile, fs.F_OK);
+			fs.accessSync(templateFile, fs.constants.F_OK);
 		} catch (err) {
 			templateFile = null;
 			Log.log("config template file not exists, no envsubst");
@@ -126,7 +126,7 @@ function App () {
 		require(`${global.root_path}/js/check_config.js`);
 
 		try {
-			fs.accessSync(configFilename, fs.F_OK);
+			fs.accessSync(configFilename, fs.constants.F_OK);
 			const c = require(configFilename);
 			if (Object.keys(c).length === 0) {
 				Log.error("WARNING! Config file appears empty, maybe missing module.exports last line?");
@@ -198,7 +198,7 @@ function App () {
 		const moduleFile = `${moduleFolder}/${moduleName}.js`;
 
 		try {
-			fs.accessSync(moduleFile, fs.R_OK);
+			fs.accessSync(moduleFile, fs.constants.R_OK);
 		} catch (e) {
 			Log.warn(`No ${moduleFile} found for module: ${moduleName}.`);
 		}
@@ -207,7 +207,7 @@ function App () {
 
 		let loadHelper = true;
 		try {
-			fs.accessSync(helperPath, fs.R_OK);
+			fs.accessSync(helperPath, fs.constants.R_OK);
 		} catch (e) {
 			loadHelper = false;
 			Log.log(`No helper found for module: ${moduleName}.`);

--- a/js/check_config.js
+++ b/js/check_config.js
@@ -35,7 +35,7 @@ function checkConfigFile () {
 
 	// Check permission
 	try {
-		fs.accessSync(configFileName, fs.F_OK);
+		fs.accessSync(configFileName, fs.constants.F_OK);
 	} catch (error) {
 		throw new Error(`${error}\nNo permission to access config file!`);
 	}


### PR DESCRIPTION
`fs.F_OK` and `fs.R_OK` are [deprecated since a while node 20.8.0](https://nodejs.org/api/deprecations.html#DEP0176).

Node 24 now complains about them when running server mode (`node --run server`):

```bash
[2025-05-23 23:11:44.932] [ERROR] (node:37733) [DEP0176] DeprecationWarning: fs.F_OK is deprecated, use fs.constants.F_OK instead
(Use `node --trace-deprecation ...` to show where the warning was created) 
```

The replacements have been in place for a while, and this change should work without any issues.