### PR TITLE
[tests] Review and refactor translation tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ planned for 2025-07-01
   - Removed as many of the date conversions as possible
   - Use `moment-timezone` when calculating recurring events, this will fix problems from the past with offsets and DST not being handled properly
   - Added some tests to test the behavior of the refactored methods to make sure the correct event dates are returned
-- [linter] Enable ESLint rule `no-console` and replace `console` with `Log` in some files
+- [linter] Enable ESLint rule `no-console` and replace `console` with `Log` in some files (#3810)
+- [tests] Review and refactor translation tests (#3792)
 
 ### Fixed
 


### PR DESCRIPTION
I have refactored the translations tests, they should now be clearer and easier to understand. There should be no functional impact.

I have discarded the original approach of also replacing `XMLHttpRequest` with `fetch` in the file `js/translator.js`. I had managed to get it to work functionally, but I couldn't get the tests to work.