### PR TITLE
Fix calendar js timestamp conversion

### DIFF
--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -586,12 +586,13 @@ Module.register("calendar", {
 	},
 
 	/**
-	 * converts the given timestamp to a moment with a timezone
+	 * Converts the given timestamp to a moment with a timezone.
+	 * But keeps the localtime since the unix timestamp is already in local timezone.
 	 * @param {number} timestamp timestamp from an event
 	 * @returns {moment.Moment} moment with a timezone
 	 */
 	timestampToMoment (timestamp) {
-		return moment(timestamp, "x").tz(moment.tz.guess());
+		return moment(timestamp, "x").tz(moment.tz.guess(), true);
 	},
 
 	/**

--- a/modules/default/calendar/calendarfetcherutils.js
+++ b/modules/default/calendar/calendarfetcherutils.js
@@ -268,10 +268,11 @@ const CalendarFetcherUtils = {
 
 						if (showRecurrence === true) {
 							Log.debug(`saving event: ${recurrenceTitle}`);
+							// TODO Make the event start and endDate a UTC unix timestamp, but this break compatibility with other modules
 							newEvents.push({
 								title: recurrenceTitle,
-								startDate: recurringEventStartMoment.format("x"),
-								endDate: recurringEventEndMoment.format("x"),
+								startDate: recurringEventStartMoment.format("x"), // This is a local timezone unix timestamp
+								endDate: recurringEventEndMoment.format("x"), // This is a local timezone unix timestamp
 								fullDayEvent: CalendarFetcherUtils.isFullDayEvent(event),
 								recurringEvent: true,
 								class: event.class,
@@ -323,10 +324,11 @@ const CalendarFetcherUtils = {
 					}
 
 					// Every thing is good. Add it to the list.
+					// TODO Make the event start and endDate a UTC unix timestamp, but this break compatibility with other modules
 					newEvents.push({
 						title: title,
-						startDate: eventStartMoment.format("x"),
-						endDate: eventEndMoment.format("x"),
+						startDate: eventStartMoment.format("x"), // This is a local timezone unix timestamp
+						endDate: eventEndMoment.format("x"), // This is a local timezone unix timestamp
 						fullDayEvent: fullDayEvent,
 						recurringEvent: false,
 						class: event.class,

--- a/tests/unit/modules/default/calendar/calendar_fetcher_utils_spec.js
+++ b/tests/unit/modules/default/calendar/calendar_fetcher_utils_spec.js
@@ -10,7 +10,7 @@ describe("Calendar fetcher utils test", () => {
 		excludedEvents: [],
 		includePastEvents: false,
 		maximumEntries: 10,
-		maximumNumberOfDays: 365
+		maximumNumberOfDays: 367
 	};
 
 	describe("filterEvents", () => {
@@ -53,7 +53,6 @@ describe("Calendar fetcher utils test", () => {
 			expect(filteredEvents[1].title).toBe("upcomingEvent");
 		});
 
-		/*
 		it("should return the correct times when recurring events pass through daylight saving time", () => {
 			const data = ical.parseICS(`BEGIN:VEVENT
 DTSTART;TZID=Europe/Amsterdam:20250311T090000
@@ -87,7 +86,6 @@ END:VEVENT`);
 			expect(januaryFirst[0].startDate).toEqual(januaryMoment.format("x"));
 			expect(julyFirst[0].startDate).toEqual(julyMoment.format("x"));
 		});
-*/
 
 		it("should return the correct moments based on the timezone given", () => {
 			const data = ical.parseICS(`BEGIN:VEVENT


### PR DESCRIPTION
This fixes a bug in the calendar.js method where the local timezone unix timestamp is converted to a moment. And it also fixes the broken unittest on 01-01 and 01-07.
