### PR TITLE
feat: enhance system information logging format and include additional env and RAM details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Thanks to: @dathbe.
 ### Changed
 
 - [clock] Add CSS to prevent line breaking of sunset/sunrise time display (#3816)
+- [core] Enhance system information logging format and include additional env and RAM details
 
 ### Updated
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -23,12 +23,16 @@ module.exports = {
 				osInfo: "platform, distro, release, arch",
 				versions: "kernel, node, npm, pm2"
 			});
-			let systemDataString = `System information:
-					### SYSTEM:   manufacturer: ${staticData.system.manufacturer}; model: ${staticData.system.model}; virtual: ${staticData.system.virtual}
-					### OS:       platform: ${staticData.osInfo.platform}; distro: ${staticData.osInfo.distro}; release: ${staticData.osInfo.release}; arch: ${staticData.osInfo.arch}; kernel: ${staticData.versions.kernel}
-					### VERSIONS: electron: ${process.versions.electron}; used node: ${staticData.versions.node}; installed node: ${installedNodeVersion}; npm: ${staticData.versions.npm}; pm2: ${staticData.versions.pm2}
-					### OTHER:    timeZone: ${Intl.DateTimeFormat().resolvedOptions().timeZone}; ELECTRON_ENABLE_GPU: ${process.env.ELECTRON_ENABLE_GPU}`
-				.replace(/\t/g, "");
+			let systemDataString = [
+				"\n#####  System Information  #####",
+				`- SYSTEM:    manufacturer: ${staticData.system.manufacturer}; model: ${staticData.system.model}; virtual: ${staticData.system.virtual}; timeZone: ${Intl.DateTimeFormat().resolvedOptions().timeZone}`,
+				`- OS:        platform: ${staticData.osInfo.platform}; distro: ${staticData.osInfo.distro}; release: ${staticData.osInfo.release}; arch: ${staticData.osInfo.arch}; kernel: ${staticData.versions.kernel}`,
+				`- VERSIONS:  electron: ${process.versions.electron}; used node: ${staticData.versions.node}; installed node: ${installedNodeVersion}; npm: ${staticData.versions.npm}; pm2: ${staticData.versions.pm2}`,
+				`- ENV:       XDG_SESSION_TYPE: ${process.env.XDG_SESSION_TYPE}; MM_CONFIG_FILE: ${process.env.MM_CONFIG_FILE};`,
+				`             WAYLAND_DISPLAY:  ${process.env.WAYLAND_DISPLAY}; DISPLAY: ${process.env.DISPLAY}; ELECTRON_ENABLE_GPU: ${process.env.ELECTRON_ENABLE_GPU}`,
+				`- RAM:       total: ${(os.totalmem() / 1024 / 1024).toFixed(2)} MB; free: ${(os.freemem() / 1024 / 1024).toFixed(2)} MB; used: ${((os.totalmem() - os.freemem()) / 1024 / 1024).toFixed(2)} MB`,
+				`- UPTIME:    ${Math.floor(os.uptime() / 60)} minutes`
+			].join("\n");
 			Log.info(systemDataString);
 
 			// Return is currently only for jest


### PR DESCRIPTION
When we introduced the system information, I selected `###` as the prefix for each line. While this doesn't cause any problems in the terminal, when someone copies the output to an issue or the forum, every line is formatted as a heading, which is not ideal. That's why I made some rework and suggest these changes.

In addition to the formatting changes, I added some env and RAM details plus the uptime. These are just suggestions – if you don't think they're worth adding, I'm happy to remove them. We wanted to keep this block compact.

@sdetweil, since you are often on the front line with the error messages from users: Is there any information missing in the system block that you often have to request additionally?

Feel free to request changes!

-----

## in the terminal

### before

```
[2025-07-09 21:58:36.943] [INFO]  System information:
### SYSTEM:   manufacturer: Notebook; model: N650DU; virtual: false
### OS:       platform: linux; distro: Debian GNU/Linux; release: 12; arch: x64; kernel: 5.10.0-20-amd64
### VERSIONS: electron: 36.3.2; used node: 24.2.0; installed node: 24.2.0; npm: 10.9.0; pm2: 6.0.6
### OTHER:    timeZone: Europe/Berlin; ELECTRON_ENABLE_GPU: undefined 
```

-----

### after

```
[2025-07-09 21:57:47.604] [INFO]  
#####  System Information  #####
- SYSTEM:    manufacturer: Notebook; model: N650DU; virtual: false; timeZone: Europe/Berlin
- OS:        platform: linux; distro: Debian GNU/Linux; release: 12; arch: x64; kernel: 5.10.0-20-amd64
- VERSIONS:  electron: 36.3.2; used node: 24.2.0; installed node: 24.2.0; npm: 10.9.0; pm2: 6.0.6
- ENV:       XDG_SESSION_TYPE: wayland; MM_CONFIG_FILE: undefined;
             WAYLAND_DISPLAY:  wayland-0; DISPLAY: :0; ELECTRON_ENABLE_GPU: undefined
- RAM:       total: 15925.45 MB; free: 967.75 MB; used: 14957.70 MB
- UPTIME:    172 minutes 
```

-----

## as markdown (in an issue or the forum)

### before

[2025-07-09 21:58:36.943] [INFO]  System information:
### SYSTEM:   manufacturer: Notebook; model: N650DU; virtual: false
### OS:       platform: linux; distro: Debian GNU/Linux; release: 12; arch: x64; kernel: 5.10.0-20-amd64
### VERSIONS: electron: 36.3.2; used node: 24.2.0; installed node: 24.2.0; npm: 10.9.0; pm2: 6.0.6
### OTHER:    timeZone: Europe/Berlin; ELECTRON_ENABLE_GPU: undefined 

-----

### after

[2025-07-09 21:57:47.604] [INFO]  
#####  System Information  #####
- SYSTEM:    manufacturer: Notebook; model: N650DU; virtual: false; timeZone: Europe/Berlin
- OS:        platform: linux; distro: Debian GNU/Linux; release: 12; arch: x64; kernel: 5.10.0-20-amd64
- VERSIONS:  electron: 36.3.2; used node: 24.2.0; installed node: 24.2.0; npm: 10.9.0; pm2: 6.0.6
- ENV:       XDG_SESSION_TYPE: wayland; MM_CONFIG_FILE: undefined;
             WAYLAND_DISPLAY:  wayland-0; DISPLAY: :0; ELECTRON_ENABLE_GPU: undefined
- RAM:       total: 15925.45 MB; free: 967.75 MB; used: 14957.70 MB
- UPTIME:    172 minutes 