### PR TITLE
refactor: optimize system information logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Thanks to: @dathbe.
 ### Changed
 
 - [clock] Add CSS to prevent line breaking of sunset/sunrise time display (#3816)
-- [core] Enhance system information logging format and include additional env and RAM details (#3839)
+- [core] Enhance system information logging format and include additional env and RAM details (#3839, #3843)
 - [refactor] Add new file `js/module_functions.js` to move code used in several modules to one place (#3837)
 
 ### Updated

--- a/js/app.js
+++ b/js/app.js
@@ -22,7 +22,7 @@ global.mmTestMode = process.env.mmTestMode === "true";
 Log.log(`Starting MagicMirror: v${global.version}`);
 
 // Log system information.
-Utils.logSystemInformation();
+Utils.logSystemInformation(global.version);
 
 // global absolute root path
 global.root_path = path.resolve(`${__dirname}/../`);

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,4 +1,3 @@
-const execSync = require("node:child_process").execSync;
 const path = require("node:path");
 
 const rootPath = path.resolve(`${__dirname}/../`);
@@ -14,31 +13,34 @@ const discoveredPositionsJSFilename = "js/positions.js";
 
 module.exports = {
 
-	async logSystemInformation  () {
+	async logSystemInformation (mirrorVersion) {
 		try {
-			let installedNodeVersion = execSync("node -v", { encoding: "utf-8" }).replace("v", "").replace(/(?:\r\n|\r|\n)/g, "");
+			const system = await si.system();
+			const osInfo = await si.osInfo();
+			const versions = await si.versions();
 
-			const staticData = await si.get({
-				system: "manufacturer, model, virtual",
-				osInfo: "platform, distro, release, arch",
-				versions: "kernel, node, npm, pm2"
-			});
+			const usedNodeVersion = process.version.replace("v", "");
+			const installedNodeVersion = versions.node;
+			const totalRam = (os.totalmem() / 1024 / 1024).toFixed(2);
+			const freeRam = (os.freemem() / 1024 / 1024).toFixed(2);
+			const usedRam = ((os.totalmem() - os.freemem()) / 1024 / 1024).toFixed(2);
+
 			let systemDataString = [
-				"\n#####  System Information  #####",
-				`- SYSTEM:    manufacturer: ${staticData.system.manufacturer}; model: ${staticData.system.model}; virtual: ${staticData.system.virtual}; timeZone: ${Intl.DateTimeFormat().resolvedOptions().timeZone}`,
-				`- OS:        platform: ${staticData.osInfo.platform}; distro: ${staticData.osInfo.distro}; release: ${staticData.osInfo.release}; arch: ${staticData.osInfo.arch}; kernel: ${staticData.versions.kernel}`,
-				`- VERSIONS:  electron: ${process.versions.electron}; used node: ${staticData.versions.node}; installed node: ${installedNodeVersion}; npm: ${staticData.versions.npm}; pm2: ${staticData.versions.pm2}`,
-				`- ENV:       XDG_SESSION_TYPE: ${process.env.XDG_SESSION_TYPE}; MM_CONFIG_FILE: ${process.env.MM_CONFIG_FILE};`,
-				`             WAYLAND_DISPLAY:  ${process.env.WAYLAND_DISPLAY}; DISPLAY: ${process.env.DISPLAY}; ELECTRON_ENABLE_GPU: ${process.env.ELECTRON_ENABLE_GPU}`,
-				`- RAM:       total: ${(os.totalmem() / 1024 / 1024).toFixed(2)} MB; free: ${(os.freemem() / 1024 / 1024).toFixed(2)} MB; used: ${((os.totalmem() - os.freemem()) / 1024 / 1024).toFixed(2)} MB`,
-				`- UPTIME:    ${Math.floor(os.uptime() / 60)} minutes`
+				"\n####  System Information  ####",
+				`- SYSTEM:   manufacturer: ${system.manufacturer}; model: ${system.model}; virtual: ${system.virtual}; MM: ${mirrorVersion}`,
+				`- OS:       platform: ${osInfo.platform}; distro: ${osInfo.distro}; release: ${osInfo.release}; arch: ${osInfo.arch}; kernel: ${versions.kernel}`,
+				`- VERSIONS: electron: ${process.versions.electron}; used node: ${usedNodeVersion}; installed node: ${installedNodeVersion}; npm: ${versions.npm}; pm2: ${versions.pm2}`,
+				`- ENV:      XDG_SESSION_TYPE: ${process.env.XDG_SESSION_TYPE}; MM_CONFIG_FILE: ${process.env.MM_CONFIG_FILE}`,
+				`            WAYLAND_DISPLAY:  ${process.env.WAYLAND_DISPLAY}; DISPLAY: ${process.env.DISPLAY}; ELECTRON_ENABLE_GPU: ${process.env.ELECTRON_ENABLE_GPU}`,
+				`- RAM:      total: ${totalRam} MB; free: ${freeRam} MB; used: ${usedRam} MB`,
+				`- OTHERS:   uptime: ${Math.floor(os.uptime() / 60)} minutes; timeZone: ${Intl.DateTimeFormat().resolvedOptions().timeZone}`
 			].join("\n");
 			Log.info(systemDataString);
 
 			// Return is currently only for jest
 			return systemDataString;
-		} catch (e) {
-			Log.error(e);
+		} catch (error) {
+			Log.error(error);
 		}
 	},
 


### PR DESCRIPTION
Additionally to #3839 did some rework on the system logging.

- feat: include MagicMirror version (like Sam suggested in #3839)
- refactor: use more variables to get the string array less complex
- refactor: get `installedNodeVersion` from si.versions (with that it was possible to drop the import of `execSync`)
- fix: `used node` was always the same as the installed one. Since Electron comes with its own node version, this can differ. This is now shown correctly (again?) with the use of `process.version`.
- a bit formatting

I think these changes make the code easier to understand and therefore easier to maintain. Except for showing the MM version there is no big difference for the user.

## before

```bash
#####  System Information  #####
- SYSTEM:    manufacturer: Notebook; model: N650DU; virtual: false; timeZone: Europe/Berlin
- OS:        platform: linux; distro: Debian GNU/Linux; release: 12; arch: x64; kernel: 5.10.0-20-amd64
- VERSIONS:  electron: 36.3.2; used node: 22.15.0; installed node: 22.15.0; npm: 10.9.0; pm2: 6.0.6
- ENV:       XDG_SESSION_TYPE: wayland; MM_CONFIG_FILE: config/config_MMM-PublicTransportHafas.js;
             WAYLAND_DISPLAY:  wayland-0; DISPLAY: :0; ELECTRON_ENABLE_GPU: undefined
- RAM:       total: 15925.45 MB; free: 2716.90 MB; used: 13209.04 MB
- UPTIME:    259 minutes 
```

## after

```bash
####  System Information  ####
- SYSTEM:   manufacturer: Notebook; model: N650DU; virtual: false; MM: 2.33.0-develop
- OS:       platform: linux; distro: Debian GNU/Linux; release: 12; arch: x64; kernel: 5.10.0-20-amd64
- VERSIONS: electron: 36.3.2; used node: 22.15.1; installed node: 22.15.0; npm: 10.9.0; pm2: 6.0.6
- ENV:      XDG_SESSION_TYPE: wayland; MM_CONFIG_FILE: config/config_MMM-PublicTransportHafas.js
            WAYLAND_DISPLAY:  wayland-0; DISPLAY: :0; ELECTRON_ENABLE_GPU: undefined
- RAM:      total: 15925.45 MB; free: 2814.49 MB; used: 13110.96 MB
- OTHERS:   uptime: 260 minutes; timeZone: Europe/Berlin 
```
