### PR TITLE
refactor: simplify jest config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Thanks to: @dathbe.
 - [clock] Add CSS to prevent line breaking of sunset/sunrise time display (#3816)
 - [core] Enhance system information logging format and include additional env and RAM details (#3839, #3843)
 - [refactor] Add new file `js/module_functions.js` to move code used in several modules to one place (#3837)
+- [tests] refactor: simplify jest config file
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Thanks to: @dathbe.
 - [clock] Add CSS to prevent line breaking of sunset/sunrise time display (#3816)
 - [core] Enhance system information logging format and include additional env and RAM details (#3839, #3843)
 - [refactor] Add new file `js/module_functions.js` to move code used in several modules to one place (#3837)
-- [tests] refactor: simplify jest config file
+- [tests] refactor: simplify jest config file (#3844)
 
 ### Updated
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = async () => {
+module.exports = () => {
 	return {
 		verbose: true,
 		testTimeout: 20000,

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,7 +25,12 @@ module.exports = async () => {
 				testPathIgnorePatterns: ["<rootDir>/tests/e2e/helpers", "<rootDir>/tests/e2e/mocks"]
 			}
 		],
-		collectCoverageFrom: ["./clientonly/**/*.js", "./js/**/*.js", "./modules/default/**/*.js", "./serveronly/**/*.js"],
+		collectCoverageFrom: [
+			"<rootDir>/clientonly/**/*.js",
+			"<rootDir>/js/**/*.js",
+			"<rootDir>/modules/default/**/*.js",
+			"<rootDir>/serveronly/**/*.js"
+		],
 		coverageReporters: ["lcov", "text"],
 		coverageProvider: "v8"
 	};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,37 +1,37 @@
-module.exports = () => {
-	return {
-		verbose: true,
-		testTimeout: 20000,
-		testSequencer: "<rootDir>/tests/utils/test_sequencer.js",
-		projects: [
-			{
-				displayName: "unit",
-				globalSetup: "<rootDir>/tests/unit/helpers/global-setup.js",
-				moduleNameMapper: {
-					logger: "<rootDir>/js/logger.js"
-				},
-				testMatch: ["**/tests/unit/**/*.[jt]s?(x)"],
-				testPathIgnorePatterns: ["<rootDir>/tests/unit/mocks", "<rootDir>/tests/unit/helpers"]
+const config = {
+	verbose: true,
+	testTimeout: 20000,
+	testSequencer: "<rootDir>/tests/utils/test_sequencer.js",
+	projects: [
+		{
+			displayName: "unit",
+			globalSetup: "<rootDir>/tests/unit/helpers/global-setup.js",
+			moduleNameMapper: {
+				logger: "<rootDir>/js/logger.js"
 			},
-			{
-				displayName: "electron",
-				testMatch: ["**/tests/electron/**/*.[jt]s?(x)"],
-				testPathIgnorePatterns: ["<rootDir>/tests/electron/helpers"]
-			},
-			{
-				displayName: "e2e",
-				testMatch: ["**/tests/e2e/**/*.[jt]s?(x)"],
-				modulePaths: ["<rootDir>/js/"],
-				testPathIgnorePatterns: ["<rootDir>/tests/e2e/helpers", "<rootDir>/tests/e2e/mocks"]
-			}
-		],
-		collectCoverageFrom: [
-			"<rootDir>/clientonly/**/*.js",
-			"<rootDir>/js/**/*.js",
-			"<rootDir>/modules/default/**/*.js",
-			"<rootDir>/serveronly/**/*.js"
-		],
-		coverageReporters: ["lcov", "text"],
-		coverageProvider: "v8"
-	};
+			testMatch: ["**/tests/unit/**/*.[jt]s?(x)"],
+			testPathIgnorePatterns: ["<rootDir>/tests/unit/mocks", "<rootDir>/tests/unit/helpers"]
+		},
+		{
+			displayName: "electron",
+			testMatch: ["**/tests/electron/**/*.[jt]s?(x)"],
+			testPathIgnorePatterns: ["<rootDir>/tests/electron/helpers"]
+		},
+		{
+			displayName: "e2e",
+			testMatch: ["**/tests/e2e/**/*.[jt]s?(x)"],
+			modulePaths: ["<rootDir>/js/"],
+			testPathIgnorePatterns: ["<rootDir>/tests/e2e/helpers", "<rootDir>/tests/e2e/mocks"]
+		}
+	],
+	collectCoverageFrom: [
+		"<rootDir>/clientonly/**/*.js",
+		"<rootDir>/js/**/*.js",
+		"<rootDir>/modules/default/**/*.js",
+		"<rootDir>/serveronly/**/*.js"
+	],
+	coverageReporters: ["lcov", "text"],
+	coverageProvider: "v8"
 };
+
+module.exports = config;


### PR DESCRIPTION
- changed export from async to sync function - this removes unnecessary complexity
- reformatted `collectCoverageFrom` to use `<rootDir>` for each pattern and switch to multi-line style - this is just harmonization