### PR TITLE
cleanup and try to stabilize weather e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Thanks to: @dathbe.
 - [tests] refactor: simplify jest config file (#3844)
 - [tests] refactor: extract constants for weather electron tests (#3845)
 - [tests] replace `console` with `Log` in calendar `debug.js` to avoid exception in eslint config (#3846)
-- [tests] speed up e2e tests (#3847)
+- [tests] speed up e2e tests, cleanup and stabilize weather e2e tests (#3847, #3848)
 
 ### Updated
 

--- a/modules/default/weather/weather.js
+++ b/modules/default/weather/weather.js
@@ -163,7 +163,8 @@ Module.register("weather", {
 	// What to do when the weather provider has new information available?
 	updateAvailable () {
 		Log.log("New weather information available.");
-		this.updateDom(0);
+		// this value was changed from 0 to 300 to stabilize weather tests:
+		this.updateDom(300);
 		this.scheduleUpdate();
 
 		if (this.weatherProvider.currentWeather()) {

--- a/tests/e2e/helpers/weather-functions.js
+++ b/tests/e2e/helpers/weather-functions.js
@@ -1,4 +1,4 @@
-const { injectMockData } = require("../../utils/weather_mocker");
+const { injectMockData, cleanupMockData } = require("../../utils/weather_mocker");
 const helpers = require("./global-setup");
 
 exports.getText = async (element, result) => {
@@ -13,7 +13,12 @@ exports.getText = async (element, result) => {
 	return true;
 };
 
-exports.startApp = async (configFileName, additionalMockData) => {
+exports.startApplication = async (configFileName, additionalMockData) => {
 	await helpers.startApplication(injectMockData(configFileName, additionalMockData));
 	await helpers.getDocument();
+};
+
+exports.stopApplication = async () => {
+	await helpers.stopApplication();
+	cleanupMockData();
 };

--- a/tests/e2e/modules/weather_current_spec.js
+++ b/tests/e2e/modules/weather_current_spec.js
@@ -5,7 +5,7 @@ const { cleanupMockData } = require("../../utils/weather_mocker");
 describe("Weather module", () => {
 	afterAll(async () => {
 		await helpers.stopApplication();
-		await cleanupMockData();
+		cleanupMockData();
 	});
 
 	describe("Current weather", () => {

--- a/tests/e2e/modules/weather_current_spec.js
+++ b/tests/e2e/modules/weather_current_spec.js
@@ -1,17 +1,15 @@
 const helpers = require("../helpers/global-setup");
 const weatherFunc = require("../helpers/weather-functions");
-const { cleanupMockData } = require("../../utils/weather_mocker");
 
 describe("Weather module", () => {
 	afterAll(async () => {
-		await helpers.stopApplication();
-		cleanupMockData();
+		await weatherFunc.stopApplication();
 	});
 
 	describe("Current weather", () => {
 		describe("Default configuration", () => {
 			beforeAll(async () => {
-				await weatherFunc.startApp("tests/configs/modules/weather/currentweather_default.js", {});
+				await weatherFunc.startApplication("tests/configs/modules/weather/currentweather_default.js", {});
 			});
 
 			it("should render wind speed and wind direction", async () => {
@@ -34,7 +32,7 @@ describe("Weather module", () => {
 
 	describe("Compliments Integration", () => {
 		beforeAll(async () => {
-			await weatherFunc.startApp("tests/configs/modules/weather/currentweather_compliments.js", {});
+			await weatherFunc.startApplication("tests/configs/modules/weather/currentweather_compliments.js", {});
 		});
 
 		it("should render a compliment based on the current weather", async () => {
@@ -44,7 +42,7 @@ describe("Weather module", () => {
 
 	describe("Configuration Options", () => {
 		beforeAll(async () => {
-			await weatherFunc.startApp("tests/configs/modules/weather/currentweather_options.js", {});
+			await weatherFunc.startApplication("tests/configs/modules/weather/currentweather_options.js", {});
 		});
 
 		it("should render windUnits in beaufort", async () => {
@@ -72,7 +70,7 @@ describe("Weather module", () => {
 
 	describe("Current weather with imperial units", () => {
 		beforeAll(async () => {
-			await weatherFunc.startApp("tests/configs/modules/weather/currentweather_units.js", {});
+			await weatherFunc.startApplication("tests/configs/modules/weather/currentweather_units.js", {});
 		});
 
 		it("should render wind in imperial units", async () => {

--- a/tests/e2e/modules/weather_forecast_spec.js
+++ b/tests/e2e/modules/weather_forecast_spec.js
@@ -5,7 +5,7 @@ const { cleanupMockData } = require("../../utils/weather_mocker");
 describe("Weather module: Weather Forecast", () => {
 	afterAll(async () => {
 		await helpers.stopApplication();
-		await cleanupMockData();
+		cleanupMockData();
 	});
 
 	describe("Default configuration", () => {

--- a/tests/e2e/modules/weather_forecast_spec.js
+++ b/tests/e2e/modules/weather_forecast_spec.js
@@ -1,16 +1,14 @@
 const helpers = require("../helpers/global-setup");
 const weatherFunc = require("../helpers/weather-functions");
-const { cleanupMockData } = require("../../utils/weather_mocker");
 
 describe("Weather module: Weather Forecast", () => {
 	afterAll(async () => {
-		await helpers.stopApplication();
-		cleanupMockData();
+		await weatherFunc.stopApplication();
 	});
 
 	describe("Default configuration", () => {
 		beforeAll(async () => {
-			await weatherFunc.startApp("tests/configs/modules/weather/forecastweather_default.js", {});
+			await weatherFunc.startApplication("tests/configs/modules/weather/forecastweather_default.js", {});
 		});
 
 		const days = ["Today", "Tomorrow", "Sun", "Mon", "Tue"];
@@ -54,7 +52,7 @@ describe("Weather module: Weather Forecast", () => {
 
 	describe("Absolute configuration", () => {
 		beforeAll(async () => {
-			await weatherFunc.startApp("tests/configs/modules/weather/forecastweather_absolute.js", {});
+			await weatherFunc.startApplication("tests/configs/modules/weather/forecastweather_absolute.js", {});
 		});
 
 		const days = ["Fri", "Sat", "Sun", "Mon", "Tue"];
@@ -67,7 +65,7 @@ describe("Weather module: Weather Forecast", () => {
 
 	describe("Configuration Options", () => {
 		beforeAll(async () => {
-			await weatherFunc.startApp("tests/configs/modules/weather/forecastweather_options.js", {});
+			await weatherFunc.startApplication("tests/configs/modules/weather/forecastweather_options.js", {});
 		});
 
 		it("should render custom table class", async () => {
@@ -94,7 +92,7 @@ describe("Weather module: Weather Forecast", () => {
 
 	describe("Forecast weather with imperial units", () => {
 		beforeAll(async () => {
-			await weatherFunc.startApp("tests/configs/modules/weather/forecastweather_units.js", {});
+			await weatherFunc.startApplication("tests/configs/modules/weather/forecastweather_units.js", {});
 		});
 
 		describe("Temperature units", () => {

--- a/tests/e2e/modules/weather_hourly_spec.js
+++ b/tests/e2e/modules/weather_hourly_spec.js
@@ -1,16 +1,13 @@
-const helpers = require("../helpers/global-setup");
 const weatherFunc = require("../helpers/weather-functions");
-const { cleanupMockData } = require("../../utils/weather_mocker");
 
 describe("Weather module: Weather Hourly Forecast", () => {
 	afterAll(async () => {
-		await helpers.stopApplication();
-		cleanupMockData();
+		await weatherFunc.stopApplication();
 	});
 
 	describe("Default configuration", () => {
 		beforeAll(async () => {
-			await weatherFunc.startApp("tests/configs/modules/weather/hourlyweather_default.js", {});
+			await weatherFunc.startApplication("tests/configs/modules/weather/hourlyweather_default.js", {});
 		});
 
 		const minTemps = ["7:00 pm", "8:00 pm", "9:00 pm", "10:00 pm", "11:00 pm"];
@@ -23,7 +20,7 @@ describe("Weather module: Weather Hourly Forecast", () => {
 
 	describe("Hourly weather options", () => {
 		beforeAll(async () => {
-			await weatherFunc.startApp("tests/configs/modules/weather/hourlyweather_options.js", {});
+			await weatherFunc.startApplication("tests/configs/modules/weather/hourlyweather_options.js", {});
 		});
 
 		describe("Hourly increments of 2", () => {
@@ -38,7 +35,7 @@ describe("Weather module: Weather Hourly Forecast", () => {
 
 	describe("Show precipitations", () => {
 		beforeAll(async () => {
-			await weatherFunc.startApp("tests/configs/modules/weather/hourlyweather_showPrecipitation.js", {});
+			await weatherFunc.startApplication("tests/configs/modules/weather/hourlyweather_showPrecipitation.js", {});
 		});
 
 		describe("Shows precipitation amount", () => {

--- a/tests/e2e/modules/weather_hourly_spec.js
+++ b/tests/e2e/modules/weather_hourly_spec.js
@@ -5,7 +5,7 @@ const { cleanupMockData } = require("../../utils/weather_mocker");
 describe("Weather module: Weather Hourly Forecast", () => {
 	afterAll(async () => {
 		await helpers.stopApplication();
-		await cleanupMockData();
+		cleanupMockData();
 	});
 
 	describe("Default configuration", () => {

--- a/tests/electron/modules/weather_spec.js
+++ b/tests/electron/modules/weather_spec.js
@@ -12,7 +12,7 @@ const EXPECTED_SUNSET_TEXT = "3:45 pm";
 describe("Weather module", () => {
 	afterEach(async () => {
 		await helpers.stopApplication();
-		await cleanupMockData();
+		cleanupMockData();
 	});
 
 	describe("Current weather with sunrise", () => {

--- a/tests/utils/weather_mocker.js
+++ b/tests/utils/weather_mocker.js
@@ -1,7 +1,6 @@
 const fs = require("node:fs");
 const path = require("node:path");
-const util = require("node:util");
-const exec = util.promisify(require("node:child_process").exec);
+const exec = require("node:child_process").execSync;
 
 /**
  * @param {string} type what data to read, can be "current" "forecast" or "hourly
@@ -45,9 +44,9 @@ const injectMockData = (configFileName, extendedData = {}) => {
 	return tempFile;
 };
 
-const cleanupMockData = async () => {
+const cleanupMockData = () => {
 	const tempDir = path.resolve(`${__dirname}/../configs`).toString();
-	await exec(`find ${tempDir} -type f -name *_temp.js -delete`);
+	exec(`find ${tempDir} -type f -name *_temp.js -delete`);
 };
 
 module.exports = { injectMockData, cleanupMockData };


### PR DESCRIPTION
The weather e2e tests are failing sometimes, failing is not really reproducable.

After changing `updateDom(0)` to `updateDom(300)` in `weather.js` it seems to work (we will se if it really works in the long term).

This PR contains some other weather e2e changes/cleanups/simplifying.

