### PR TITLE
tests: add `setupDOMEnvironment` helper function to eliminate repetitive JSDOM setup code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Thanks to: @dathbe.
 - [refactor] Add new file `js/module_functions.js` to move code used in several modules to one place (#3837)
 - [tests] refactor: simplify jest config file (#3844)
 - [tests] refactor: extract constants for weather electron tests (#3845)
+- [tests] refactor: add `setupDOMEnvironment` helper function to eliminate repetitive JSDOM setup code
 - [tests] replace `console` with `Log` in calendar `debug.js` to avoid exception in eslint config (#3846)
 - [tests] speed up e2e tests, cleanup and stabilize weather e2e tests (#3847, #3848)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Thanks to: @dathbe.
 - [refactor] Add new file `js/module_functions.js` to move code used in several modules to one place (#3837)
 - [tests] refactor: simplify jest config file (#3844)
 - [tests] refactor: extract constants for weather electron tests (#3845)
-- [tests] refactor: add `setupDOMEnvironment` helper function to eliminate repetitive JSDOM setup code
+- [tests] refactor: add `setupDOMEnvironment` helper function to eliminate repetitive JSDOM setup code (#3860)
 - [tests] replace `console` with `Log` in calendar `debug.js` to avoid exception in eslint config (#3846)
 - [tests] speed up e2e tests, cleanup and stabilize weather e2e tests (#3847, #3848)
 


### PR DESCRIPTION
The helper function allows to remove a lot of repetitive code, making the tests clearer and easier to maintain.
