### PR TITLE
tests: update jest snapshot url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Thanks to: @dathbe.
 - [tests] refactor: extract constants for weather electron tests (#3845)
 - [tests] refactor: add `setupDOMEnvironment` helper function to eliminate repetitive JSDOM setup code (#3860)
 - [tests] replace `console` with `Log` in calendar `debug.js` to avoid exception in eslint config (#3846)
-- [tests] speed up e2e tests, cleanup and stabilize weather e2e tests (#3847, #3848)
+- [tests] speed up e2e tests, cleanup and stabilize weather e2e tests, update snapshot url (#3847, #3848, #3861)
 
 ### Updated
 

--- a/tests/unit/functions/__snapshots__/updatenotification_spec.js.snap
+++ b/tests/unit/functions/__snapshots__/updatenotification_spec.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Updatenotification custom module returns status information without hash 1`] = `
 {


### PR DESCRIPTION
This is not a cosmetic change because jest errors when run with `CI=true`.

I got this error when running unit tests in gitlab:

```bash
FAIL unit tests/unit/functions/updatenotification_spec.js
  ● Test suite failed to run
    Outdated guide link: The snapshot guide link is outdated.Please update all snapshots while upgrading of Jest
    Expected: https://jestjs.io/docs/snapshot-testing
    Received: https://goo.gl/fbAQLP
      at validateSnapshotHeader (node_modules/@jest/snapshot-utils/build/index.js:104:12)
      at getSnapshotData (node_modules/@jest/snapshot-utils/build/index.js:156:28)
```

If you run the test without `CI=true` jest will update the file.