### PR TITLE
fix for #3380, socket.io timeout closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Thanks to: @dathbe.
 - [calendar] Fixed broken unittest that only broke on the 1st of July and 1st of january (#3830)
 - [clock] Fixed missing icons when no other modules with icons is loaded (#3834)
 - [weather] Fixed handling of empty values in weathergov providers handling of precipitationAmount (#3859)
+- [core] Fixed socket.io timeout when server is slow to send notification, notification lost at client (#3380)
 
 ## [2.32.0] - 2025-07-01
 

--- a/js/server.js
+++ b/js/server.js
@@ -42,7 +42,9 @@ function Server (config) {
 					origin: /.*$/,
 					credentials: true
 				},
-				allowEIO3: true
+				allowEIO3: true,
+				pingInterval: 120000, // server → client ping every 2 mins   //add
+				pingTimeout: 120000 // wait up to 2 mins for client pong   //add
 			});
 
 			server.on("connection", (socket) => {

--- a/js/server.js
+++ b/js/server.js
@@ -43,8 +43,8 @@ function Server (config) {
 					credentials: true
 				},
 				allowEIO3: true,
-				pingInterval: 120000, // server → client ping every 2 mins   //add
-				pingTimeout: 120000 // wait up to 2 mins for client pong   //add
+				pingInterval: 120000, // server → client ping every 2 mins
+				pingTimeout: 120000 // wait up to 2 mins for client pong
 			});
 
 			server.on("connection", (socket) => {

--- a/js/socketclient.js
+++ b/js/socketclient.js
@@ -13,7 +13,9 @@ const MMSocket = function (moduleName) {
 		base = config.basePath;
 	}
 	this.socket = io(`/${this.moduleName}`, {
-		path: `${base}socket.io`
+		path: `${base}socket.io`,
+		pingInterval: 120000, // send pings every 2 mins     // add
+		pingTimeout: 120000 // wait up to 2 mins for a pong  // add
 	});
 
 	let notificationCallback = function () {};

--- a/js/socketclient.js
+++ b/js/socketclient.js
@@ -14,8 +14,8 @@ const MMSocket = function (moduleName) {
 	}
 	this.socket = io(`/${this.moduleName}`, {
 		path: `${base}socket.io`,
-		pingInterval: 120000, // send pings every 2 mins     // add
-		pingTimeout: 120000 // wait up to 2 mins for a pong  // add
+		pingInterval: 120000, // send pings every 2 mins
+		pingTimeout: 120000 // wait up to 2 mins for a pong
 	});
 
 	let notificationCallback = function () {};


### PR DESCRIPTION
socket.io times out and closes the client side socket without any callback
sendSocntNotification() from the server side data is lost as the socket is closed.  but the client doesn't know

increase the timeout 

fixes #3380
