### PR TITLE
[weather] use 'apparent_temperature' in openmeteos data for feelsLike temperature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Thanks to: @dathbe.
 - [calendar] Fix regression handling of limit days (#3840)
 - [calendar] Fixed regression of calendarfetcherutils.shouldEventBeExcluded (#3841)
 - [core] Fixed socket.io timeout when server is slow to send notification, notification lost at client (#3380)
-- [weather] Use `apparent_temperature` data from openmeteo's hourly weather for current feelsLikeTemp ().
+- [weather] Use `apparent_temperature` data from openmeteo's hourly weather for current feelsLikeTemp (#3868).
 
 ## [2.32.0] - 2025-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Thanks to: @dathbe.
 - [calendar] Fix regression handling of limit days (#3840)
 - [calendar] Fixed regression of calendarfetcherutils.shouldEventBeExcluded (#3841)
 - [core] Fixed socket.io timeout when server is slow to send notification, notification lost at client (#3380)
+- [weather] Use `apparent_temperature` data from openmeteo's hourly weather for current feelsLikeTemp ().
 
 ## [2.32.0] - 2025-07-01
 
@@ -729,7 +730,7 @@ Special thanks to the following contributors: @AmpioRosso, @eouia, @fewieden, @j
 ### Fixed
 
 - Fixed wrong file `kr.json` to `ko.json`. Use language code 'ko' instead of 'kr' for Korean language.
-- Fixed `feels_like` data from openweathermap's current weather being ignored (#2678).
+- [weather] Fixed `feels_like` data from openweathermap's current weather being ignored (#2678).
 - Fixed chaotic newsfeed display after network connection loss thanks to @jalibu (#2638).
 - Fixed incorrect time zone correction of recurring full day events (#2632 and #2634).
 - Fixed e2e tests by increasing testTimeout.

--- a/modules/default/weather/providers/openmeteo.js
+++ b/modules/default/weather/providers/openmeteo.js
@@ -13,7 +13,7 @@ WeatherProvider.register("openmeteo", {
 
 	/*
 	 * Set the name of the provider.
-	 * Not strictly required, but helps for debugging.
+	 * Not strictly required but helps for debugging.
 	 */
 	providerName: "Open-Meteo",
 
@@ -348,7 +348,7 @@ WeatherProvider.register("openmeteo", {
 	generateWeatherDayFromCurrentWeather (weather) {
 
 		/**
-		 * Since some units comes from API response "splitted" into daily, hourly and current_weather
+		 * Since some units come from API response "splitted" into daily, hourly and current_weather
 		 * every time you request it, you have to ensure to get the data from the right place every time.
 		 * For the current weather case, the response have the following structure (after transposing):
 		 * ```

--- a/modules/default/weather/providers/openmeteo.js
+++ b/modules/default/weather/providers/openmeteo.js
@@ -381,6 +381,7 @@ WeatherProvider.register("openmeteo", {
 		currentWeather.maxTemperature = parseFloat(weather.daily[0].temperature_2m_max);
 		currentWeather.weatherType = this.convertWeatherType(weather.current_weather.weathercode, currentWeather.isDayTime());
 		currentWeather.humidity = parseFloat(weather.hourly[h].relativehumidity_2m);
+		currentWeather.feelsLikeTemp = parseFloat(weather.hourly[h].apparent_temperature);
 		currentWeather.rain = parseFloat(weather.hourly[h].rain);
 		currentWeather.snow = parseFloat(weather.hourly[h].snowfall * 10);
 		currentWeather.precipitationAmount = parseFloat(weather.hourly[h].precipitation);

--- a/modules/default/weather/weatherutils.js
+++ b/modules/default/weather/weatherutils.js
@@ -53,7 +53,7 @@ const WeatherUtils = {
 	/**
 	 * Convert temp (from degrees C) into imperial or metric unit depending on
 	 * your config
-	 * @param {number} tempInC the temperature in celsius you want to convert
+	 * @param {number} tempInC the temperature in Celsius you want to convert
 	 * @param {string} unit can be 'imperial' or 'metric'
 	 * @returns {number} the converted temperature
 	 */

--- a/tests/unit/modules/default/weather/weather_utils_spec.js
+++ b/tests/unit/modules/default/weather/weather_utils_spec.js
@@ -2,7 +2,7 @@ const weather = require("../../../../../modules/default/weather/weatherutils");
 const WeatherUtils = require("../../../../../modules/default/weather/weatherutils");
 
 describe("Weather utils tests", () => {
-	describe("windspeed conversion to imperial", () => {
+	describe("temperature conversion to imperial", () => {
 		it("should convert temp correctly from Celsius to Fahrenheit", () => {
 			expect(Math.round(WeatherUtils.convertTemp(10, "imperial"))).toBe(50);
 		});


### PR DESCRIPTION
The data is here, it just wasnt used.

The general feelsLike calculation seems odd too (but maybe thats another PR). It always returned the same temp as the current temp in the openmeteo data, thats why I looked into it.