### PR TITLE
update default icon for calendars

### DIFF
--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -8,7 +8,7 @@ Module.register("calendar", {
 		limitDays: 0, // Limit the number of days shown, 0 = no limit
 		pastDaysCount: 0,
 		displaySymbol: true,
-		defaultSymbol: "calendar-alt", // Fontawesome Symbol see https://fontawesome.com/cheatsheet?from=io
+		defaultSymbol: "calendar-days", // Fontawesome Symbol see https://fontawesome.com/search?ic=free&o=r
 		defaultSymbolClassName: "fas fa-fw fa-",
 		showLocation: false,
 		displayRepeatingCountTitle: false,


### PR DESCRIPTION
While looking at https://github.com/MagicMirrorOrg/MagicMirror-Documentation/issues/114 I noticed that the default icon is not named correctly. 

`calendar-alt` should be called `calendar-days` which seems to be its fallback anyways.

I also updated the link to the icon search