### PR TITLE
feat(weather): enable CSS ordering for forecast and hourly columns

### DIFF
--- a/defaultmodules/weather/current.njk
+++ b/defaultmodules/weather/current.njk
@@ -36,10 +36,10 @@
         </span>
       {% endif %}
       {% if config.showUVIndex %}
-        <td class="align-right bright uv-index">
+        <div class="align-right bright uv-index">
           <div class="wi dimmed wi-hot"></div>
           {{ current.uvIndex }}
-        </td>
+        </div>
       {% endif %}
     </div>
   {% endif %}

--- a/defaultmodules/weather/forecast.njk
+++ b/defaultmodules/weather/forecast.njk
@@ -21,19 +21,19 @@
         <td class="bright weather-icon">
           <span class="wi weathericon wi-{{ f.weatherType }}"></span>
         </td>
-        <td class="align-right bright max-temp">{{ f.maxTemperature | roundValue | unit("temperature") | decimalSymbol }}</td>
         <td class="align-right min-temp">{{ f.minTemperature | roundValue | unit("temperature") | decimalSymbol }}</td>
-        {% if config.showPrecipitationAmount %}
-          <td class="align-right bright precipitation-amount">{{ f.precipitationAmount | unit("precip", f.precipitationUnits) }}</td>
-        {% endif %}
-        {% if config.showPrecipitationProbability %}
-          <td class="align-right bright precipitation-prob">{{ f.precipitationProbability | unit('precip', '%') }}</td>
-        {% endif %}
+        <td class="align-right bright max-temp">{{ f.maxTemperature | roundValue | unit("temperature") | decimalSymbol }}</td>
         {% if config.showUVIndex %}
           <td class="align-right dimmed uv-index">
             {{ f.uvIndex }}
             <span class="wi dimmed weathericon wi-hot"></span>
           </td>
+        {% endif %}
+        {% if config.showPrecipitationAmount %}
+          <td class="align-right bright precipitation-amount">{{ f.precipitationAmount | unit("precip", f.precipitationUnits) }}</td>
+        {% endif %}
+        {% if config.showPrecipitationProbability %}
+          <td class="align-right bright precipitation-prob">{{ f.precipitationProbability | unit('precip', '%') }}</td>
         {% endif %}
       </tr>
       {% set currentStep = currentStep + 1 %}

--- a/defaultmodules/weather/forecast.njk
+++ b/defaultmodules/weather/forecast.njk
@@ -1,7 +1,7 @@
 {% if forecast %}
   {% set numSteps = forecast | calcNumSteps %}
   {% set currentStep = 0 %}
-  <table class="{{ config.tableClass }}">
+  <table class="{{ config.tableClass }} weather-forecast">
     {% if config.ignoreToday %}
       {% set forecast = forecast.splice(1) %}
     {% endif %}

--- a/defaultmodules/weather/forecast.njk
+++ b/defaultmodules/weather/forecast.njk
@@ -1,44 +1,41 @@
 {% if forecast %}
   {% set numSteps = forecast | calcNumSteps %}
   {% set currentStep = 0 %}
-  <table class="{{ config.tableClass }} weather-forecast">
+  <div class="{{ config.tableClass }} weather-forecast" role="table">
     {% if config.ignoreToday %}
       {% set forecast = forecast.splice(1) %}
     {% endif %}
     {% set forecast = forecast.slice(0, numSteps) %}
     {% for f in forecast %}
-      <tr
-        {% if config.colored %}class="colored"{% endif %}
-        {% if config.fade %}style="opacity: {{ currentStep | opacity(numSteps) }};"{% endif %}
-      >
+      <div class="weather-forecast-row{% if config.colored %}{{ " colored" }}{% endif %}" role="row" {% if config.fade %}style="opacity: {{ currentStep | opacity(numSteps) }};"{% endif %}>
         {% if (currentStep == 0) and config.ignoreToday == false and config.absoluteDates == false %}
-          <td class="day">{{ "TODAY" | translate }}</td>
+          <div class="day" role="cell">{{ "TODAY" | translate }}</div>
         {% elif (currentStep == 1) and config.ignoreToday == false and config.absoluteDates == false %}
-          <td class="day">{{ "TOMORROW" | translate }}</td>
+          <div class="day" role="cell">{{ "TOMORROW" | translate }}</div>
         {% else %}
-          <td class="day">{{ f.date.format(config.forecastDateFormat) }}</td>
+          <div class="day" role="cell">{{ f.date.format(config.forecastDateFormat) }}</div>
         {% endif %}
-        <td class="bright weather-icon">
+        <div class="bright weather-icon" role="cell">
           <span class="wi weathericon wi-{{ f.weatherType }}"></span>
-        </td>
-        <td class="align-right min-temp">{{ f.minTemperature | roundValue | unit("temperature") | decimalSymbol }}</td>
-        <td class="align-right bright max-temp">{{ f.maxTemperature | roundValue | unit("temperature") | decimalSymbol }}</td>
+        </div>
+        <div class="align-right min-temp" role="cell">{{ f.minTemperature | roundValue | unit("temperature") | decimalSymbol }}</div>
+        <div class="align-right bright max-temp" role="cell">{{ f.maxTemperature | roundValue | unit("temperature") | decimalSymbol }}</div>
         {% if config.showUVIndex %}
-          <td class="align-right dimmed uv-index">
+          <div class="align-right dimmed uv-index" role="cell">
             {{ f.uvIndex }}
             <span class="wi dimmed weathericon wi-hot"></span>
-          </td>
+          </div>
         {% endif %}
         {% if config.showPrecipitationAmount %}
-          <td class="align-right bright precipitation-amount">{{ f.precipitationAmount | unit("precip", f.precipitationUnits) }}</td>
+          <div class="align-right bright precipitation-amount" role="cell">{{ f.precipitationAmount | unit("precip", f.precipitationUnits) }}</div>
         {% endif %}
         {% if config.showPrecipitationProbability %}
-          <td class="align-right bright precipitation-prob">{{ f.precipitationProbability | unit('precip', '%') }}</td>
+          <div class="align-right bright precipitation-prob" role="cell">{{ f.precipitationProbability | unit('precip', '%') }}</div>
         {% endif %}
-      </tr>
+      </div>
       {% set currentStep = currentStep + 1 %}
     {% endfor %}
-  </table>
+  </div>
 {% else %}
   <div class="dimmed light small">{{ "LOADING" | translate }}</div>
 {% endif %}

--- a/defaultmodules/weather/hourly.njk
+++ b/defaultmodules/weather/hourly.njk
@@ -1,46 +1,47 @@
 {% if hourly %}
   {% set numSteps = hourly | calcNumEntries %}
   {% set currentStep = 0 %}
-  <table class="{{ config.tableClass }}">
+  <div class="{{ config.tableClass }} weather-hourly" role="table">
     {% set hours = hourly.slice(0, numSteps) %}
     {% for hour in hours %}
-      <tr
-        {% if config.colored %}class="colored"{% endif %}
-        {% if config.fade %}style="opacity: {{ currentStep | opacity(numSteps) }};"{% endif %}
-      >
-        <td class="day">{{ hour.date | formatTime }}</td>
-        <td class="bright weather-icon">
+      <div class="weather-hourly-row{% if config.colored %}{{ " colored" }}{% endif %}" role="row" {% if config.fade %}style="opacity: {{ currentStep | opacity(numSteps) }};"{% endif %}>
+        <div class="time" role="cell">{{ hour.date | formatTime }}</div>
+        <div class="bright weather-icon" role="cell">
           <span class="wi weathericon wi-{{ hour.weatherType }}"></span>
-        </td>
-        <td class="align-right bright">{{ hour.temperature | roundValue | unit("temperature") }}</td>
+        </div>
+        <div class="align-right bright temperature" role="cell">{{ hour.temperature | roundValue | unit("temperature") }}</div>
         {% if config.showUVIndex %}
-          <td class="align-right bright uv-index">
+          <div class="align-right bright uv-index" role="cell">
             {% if hour.uvIndex!=0 %}
               {{ hour.uvIndex }}
               <span class="wi weathericon wi-hot"></span>
             {% endif %}
-          </td>
+          </div>
         {% endif %}
         {% if config.showHumidity != "none" %}
-          <td class="align-left bright humidity-hourly">
+          <div class="align-left bright humidity-hourly" role="cell">
             {{ hour.humidity }}
             <span class="wi wi-humidity humidity-icon"></span>
-          </td>
+          </div>
         {% endif %}
         {% if config.showPrecipitationAmount %}
-          {% if (not config.hideZeroes or hour.precipitationAmount>0) %}
-            <td class="align-right bright precipitation-amount">{{ hour.precipitationAmount | unit("precip", hour.precipitationUnits) }}</td>
-          {% endif %}
+          <div class="align-right bright precipitation-amount{% if config.hideZeroes and hour.precipitationAmount <= 0 %}{{ " weather-hidden" }}{% endif %}" role="cell">
+            {% if not config.hideZeroes or hour.precipitationAmount > 0 %}
+              {{ hour.precipitationAmount | unit("precip", hour.precipitationUnits) }}
+            {% endif %}
+          </div>
         {% endif %}
         {% if config.showPrecipitationProbability %}
-          {% if (not config.hideZeroes or hour.precipitationAmount>0) %}
-            <td class="align-right bright precipitation-prob">{{ hour.precipitationProbability | unit('precip', '%') }}</td>
-          {% endif %}
+          <div class="align-right bright precipitation-prob{% if config.hideZeroes and hour.precipitationAmount <= 0 %}{{ " weather-hidden" }}{% endif %}" role="cell">
+            {% if not config.hideZeroes or hour.precipitationAmount > 0 %}
+              {{ hour.precipitationProbability | unit('precip', '%') }}
+            {% endif %}
+          </div>
         {% endif %}
-      </tr>
+      </div>
       {% set currentStep = currentStep + 1 %}
     {% endfor %}
-  </table>
+  </div>
 {% else %}
   <div class="dimmed light small">{{ "LOADING" | translate }}</div>
 {% endif %}

--- a/defaultmodules/weather/weather.css
+++ b/defaultmodules/weather/weather.css
@@ -22,8 +22,12 @@
 }
 
 .weather .min-temp {
-  padding-left: 20px;
+  padding-left: 0;
   padding-right: 0;
+}
+
+.weather .max-temp {
+  padding-left: 20px;
 }
 
 .weather .precipitation-amount,

--- a/defaultmodules/weather/weather.css
+++ b/defaultmodules/weather/weather.css
@@ -11,6 +11,11 @@
   padding-bottom: 6px;
 }
 
+.weather .weather-forecast tr {
+  display: flex;
+  align-items: baseline;
+}
+
 .weather .day {
   padding-left: 0;
   padding-right: 25px;
@@ -36,6 +41,34 @@
 .weather .uv-index {
   padding-left: 20px;
   padding-right: 0;
+}
+
+.weather .weather-forecast .day {
+  order: var(--weather-forecast-day-order, 1);
+}
+
+.weather .weather-forecast .weather-icon {
+  order: var(--weather-forecast-icon-order, 2);
+}
+
+.weather .weather-forecast .min-temp {
+  order: var(--weather-forecast-min-temp-order, 3);
+}
+
+.weather .weather-forecast .max-temp {
+  order: var(--weather-forecast-max-temp-order, 4);
+}
+
+.weather .weather-forecast .uv-index {
+  order: var(--weather-forecast-uv-index-order, 5);
+}
+
+.weather .weather-forecast .precipitation-amount {
+  order: var(--weather-forecast-precipitation-amount-order, 6);
+}
+
+.weather .weather-forecast .precipitation-prob {
+  order: var(--weather-forecast-precipitation-prob-order, 7);
 }
 
 .weather tr.colored .min-temp {

--- a/defaultmodules/weather/weather.css
+++ b/defaultmodules/weather/weather.css
@@ -11,36 +11,44 @@
   padding-bottom: 6px;
 }
 
-.weather .weather-forecast tr {
-  display: flex;
+.weather .weather-forecast,
+.weather .weather-hourly {
+  display: grid;
+  width: max-content;
+  grid-template-columns: repeat(7, max-content);
+}
+
+.weather .weather-forecast-row,
+.weather .weather-hourly-row {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
   align-items: baseline;
+  column-gap: 25px;
 }
 
 .weather .day {
-  padding-left: 0;
-  padding-right: 25px;
+  white-space: nowrap;
 }
 
 .weather .weather-icon {
-  padding-right: 30px;
   text-align: center;
 }
 
 .weather .min-temp {
-  padding-left: 0;
   padding-right: 0;
 }
 
-.weather .max-temp {
-  padding-left: 20px;
-}
-
+.weather .max-temp,
 .weather .precipitation-amount,
 .weather .precipitation-prob,
 .weather .humidity-hourly,
 .weather .uv-index {
-  padding-left: 20px;
-  padding-right: 0;
+  padding: 0;
+}
+
+.weather .weather-hidden {
+  visibility: hidden;
 }
 
 .weather .weather-forecast .day {
@@ -71,11 +79,41 @@
   order: var(--weather-forecast-precipitation-prob-order, 7);
 }
 
-.weather tr.colored .min-temp {
+.weather .weather-hourly .time {
+  order: var(--weather-hourly-time-order, 1);
+  white-space: nowrap;
+}
+
+.weather .weather-hourly .weather-icon {
+  order: var(--weather-hourly-icon-order, 2);
+  text-align: center;
+}
+
+.weather .weather-hourly .temperature {
+  order: var(--weather-hourly-temperature-order, 3);
+}
+
+.weather .weather-hourly .uv-index {
+  order: var(--weather-hourly-uv-index-order, 4);
+}
+
+.weather .weather-hourly .humidity-hourly {
+  order: var(--weather-hourly-humidity-order, 5);
+}
+
+.weather .weather-hourly .precipitation-amount {
+  order: var(--weather-hourly-precipitation-amount-order, 6);
+}
+
+.weather .weather-hourly .precipitation-prob {
+  order: var(--weather-hourly-precipitation-prob-order, 7);
+}
+
+.weather .weather-forecast-row.colored .min-temp {
   color: #bcddff;
 }
 
-.weather tr.colored .max-temp {
+.weather .weather-forecast-row.colored .max-temp {
   color: #ff8e99;
 }
 

--- a/tests/e2e/modules/weather_forecast_spec.js
+++ b/tests/e2e/modules/weather_forecast_spec.js
@@ -34,7 +34,7 @@ describe("Weather module: Weather Forecast", () => {
 		const maxTemps = ["24.4°", "21.0°", "22.9°", "23.4°", "20.6°"];
 		for (const [index, temp] of maxTemps.entries()) {
 			it(`should render max temperature ${temp}`, async () => {
-				const maxTempCell = page.locator(`.weather table.small tr:nth-child(${index + 1}) td:nth-child(3)`);
+				const maxTempCell = page.locator(`.weather table.small tr:nth-child(${index + 1}) td.max-temp`);
 				await expect(maxTempCell).toHaveText(temp);
 			});
 		}
@@ -42,7 +42,7 @@ describe("Weather module: Weather Forecast", () => {
 		const minTemps = ["15.3°", "13.6°", "13.8°", "13.9°", "10.9°"];
 		for (const [index, temp] of minTemps.entries()) {
 			it(`should render min temperature ${temp}`, async () => {
-				const minTempCell = page.locator(`.weather table.small tr:nth-child(${index + 1}) td:nth-child(4)`);
+				const minTempCell = page.locator(`.weather table.small tr:nth-child(${index + 1}) td.min-temp`);
 				await expect(minTempCell).toHaveText(temp);
 			});
 		}
@@ -107,7 +107,7 @@ describe("Weather module: Weather Forecast", () => {
 			const temperatures = ["75_9°", "69_8°", "73_2°", "74_1°", "69_1°"];
 			for (const [index, temp] of temperatures.entries()) {
 				it(`should render custom decimalSymbol = '_' for temp ${temp}`, async () => {
-					const tempCell = page.locator(`.weather table.small tr:nth-child(${index + 1}) td:nth-child(3)`);
+					const tempCell = page.locator(`.weather table.small tr:nth-child(${index + 1}) td.max-temp`);
 					await expect(tempCell).toHaveText(temp);
 				});
 			}

--- a/tests/e2e/modules/weather_forecast_spec.js
+++ b/tests/e2e/modules/weather_forecast_spec.js
@@ -78,12 +78,20 @@ describe("Weather module: Weather Forecast", () => {
 		});
 
 		it("should render custom table class", async () => {
-			await expect(page.locator(".weather table.myTableClass")).toBeVisible();
+			await expect(page.locator(".weather table.myTableClass.weather-forecast")).toBeVisible();
 		});
 
 		it("should render colored rows", async () => {
 			const rows = page.locator(".weather table.myTableClass tr");
 			await expect(rows).toHaveCount(5);
+		});
+
+		it("should expose forecast column order through CSS", async () => {
+			const minTempCell = page.locator(".weather table.myTableClass tr:first-child td.min-temp");
+			const maxTempCell = page.locator(".weather table.myTableClass tr:first-child td.max-temp");
+
+			await expect(minTempCell).toHaveCSS("order", "3");
+			await expect(maxTempCell).toHaveCSS("order", "4");
 		});
 
 		const precipitations = [undefined, "2.51 mm"];

--- a/tests/e2e/modules/weather_forecast_spec.js
+++ b/tests/e2e/modules/weather_forecast_spec.js
@@ -18,7 +18,7 @@ describe("Weather module: Weather Forecast", () => {
 		const days = ["Today", "Tomorrow", "Sun", "Mon", "Tue"];
 		for (const [index, day] of days.entries()) {
 			it(`should render day ${day}`, async () => {
-				const dayCell = page.locator(`.weather table.small tr:nth-child(${index + 1}) td:nth-child(1)`);
+				const dayCell = page.locator(`.weather .weather-forecast-row:nth-child(${index + 1}) .day`);
 				await expect(dayCell).toHaveText(day);
 			});
 		}
@@ -26,7 +26,7 @@ describe("Weather module: Weather Forecast", () => {
 		const icons = ["day-cloudy", "rain", "day-sunny", "day-sunny", "day-sunny"];
 		for (const [index, icon] of icons.entries()) {
 			it(`should render icon ${icon}`, async () => {
-				const iconElement = page.locator(`.weather table.small tr:nth-child(${index + 1}) td:nth-child(2) span.wi-${icon}`);
+				const iconElement = page.locator(`.weather .weather-forecast-row:nth-child(${index + 1}) span.wi-${icon}`);
 				await expect(iconElement).toBeVisible();
 			});
 		}
@@ -34,7 +34,7 @@ describe("Weather module: Weather Forecast", () => {
 		const maxTemps = ["24.4°", "21.0°", "22.9°", "23.4°", "20.6°"];
 		for (const [index, temp] of maxTemps.entries()) {
 			it(`should render max temperature ${temp}`, async () => {
-				const maxTempCell = page.locator(`.weather table.small tr:nth-child(${index + 1}) td.max-temp`);
+				const maxTempCell = page.locator(`.weather .weather-forecast-row:nth-child(${index + 1}) .max-temp`);
 				await expect(maxTempCell).toHaveText(temp);
 			});
 		}
@@ -42,7 +42,7 @@ describe("Weather module: Weather Forecast", () => {
 		const minTemps = ["15.3°", "13.6°", "13.8°", "13.9°", "10.9°"];
 		for (const [index, temp] of minTemps.entries()) {
 			it(`should render min temperature ${temp}`, async () => {
-				const minTempCell = page.locator(`.weather table.small tr:nth-child(${index + 1}) td.min-temp`);
+				const minTempCell = page.locator(`.weather .weather-forecast-row:nth-child(${index + 1}) .min-temp`);
 				await expect(minTempCell).toHaveText(temp);
 			});
 		}
@@ -50,10 +50,18 @@ describe("Weather module: Weather Forecast", () => {
 		const opacities = [1, 1, 0.8, 0.5333333333333333, 0.2666666666666667];
 		for (const [index, opacity] of opacities.entries()) {
 			it(`should render fading of rows with opacity=${opacity}`, async () => {
-				const row = page.locator(`.weather table.small tr:nth-child(${index + 1})`);
+				const row = page.locator(`.weather .weather-forecast-row:nth-child(${index + 1})`);
 				await expect(row).toHaveAttribute("style", `opacity: ${opacity};`);
 			});
 		}
+
+		it("should align forecast columns across rows", async () => {
+			for (const column of [".day", ".weather-icon", ".min-temp", ".max-temp"]) {
+				const firstCell = await page.locator(`.weather .weather-forecast-row:nth-child(1) ${column}`).boundingBox();
+				const secondCell = await page.locator(`.weather .weather-forecast-row:nth-child(2) ${column}`).boundingBox();
+				expect(firstCell.x).toBe(secondCell.x);
+			}
+		});
 	});
 
 	describe("Absolute configuration", () => {
@@ -65,7 +73,7 @@ describe("Weather module: Weather Forecast", () => {
 		const days = ["Fri", "Sat", "Sun", "Mon", "Tue"];
 		for (const [index, day] of days.entries()) {
 			it(`should render day ${day}`, async () => {
-				const dayCell = page.locator(`.weather table.small tr:nth-child(${index + 1}) td:nth-child(1)`);
+				const dayCell = page.locator(`.weather .weather-forecast-row:nth-child(${index + 1}) .day`);
 				await expect(dayCell).toHaveText(day);
 			});
 		}
@@ -78,27 +86,55 @@ describe("Weather module: Weather Forecast", () => {
 		});
 
 		it("should render custom table class", async () => {
-			await expect(page.locator(".weather table.myTableClass.weather-forecast")).toBeVisible();
+			await expect(page.locator(".weather .myTableClass.weather-forecast")).toBeVisible();
 		});
 
 		it("should render colored rows", async () => {
-			const rows = page.locator(".weather table.myTableClass tr");
+			const rows = page.locator(".weather .myTableClass.weather-forecast .weather-forecast-row");
 			await expect(rows).toHaveCount(5);
 		});
 
+		it("should align optional columns across rows", async () => {
+			for (const column of [".precipitation-amount"]) {
+				const firstCell = await page.locator(`.weather .myTableClass.weather-forecast .weather-forecast-row:nth-child(1) ${column}`).boundingBox();
+				const secondCell = await page.locator(`.weather .myTableClass.weather-forecast .weather-forecast-row:nth-child(2) ${column}`).boundingBox();
+				const firstRow = await page.locator(".weather .myTableClass.weather-forecast .weather-forecast-row:nth-child(1)").boundingBox();
+				const secondRow = await page.locator(".weather .myTableClass.weather-forecast .weather-forecast-row:nth-child(2)").boundingBox();
+				expect(firstCell.x).toBe(secondCell.x);
+				expect(firstCell.y).toBe(firstRow.y);
+				expect(secondCell.y).toBe(secondRow.y);
+			}
+		});
+
 		it("should expose forecast column order through CSS", async () => {
-			const minTempCell = page.locator(".weather table.myTableClass tr:first-child td.min-temp");
-			const maxTempCell = page.locator(".weather table.myTableClass tr:first-child td.max-temp");
+			const minTempCell = page.locator(".weather .myTableClass.weather-forecast .weather-forecast-row:first-child .min-temp");
+			const maxTempCell = page.locator(".weather .myTableClass.weather-forecast .weather-forecast-row:first-child .max-temp");
 
 			await expect(minTempCell).toHaveCSS("order", "3");
 			await expect(maxTempCell).toHaveCSS("order", "4");
+
+			await page.addStyleTag({
+				content: `
+					       .weather .myTableClass.weather-forecast {
+						       --weather-forecast-min-temp-order: 4;
+						       --weather-forecast-max-temp-order: 3;
+					       }
+				       `
+			});
+
+			await expect(minTempCell).toHaveCSS("order", "4");
+			await expect(maxTempCell).toHaveCSS("order", "3");
+
+			const minTempBox = await minTempCell.boundingBox();
+			const maxTempBox = await maxTempCell.boundingBox();
+			expect(minTempBox.x - (maxTempBox.x + maxTempBox.width)).toBe(25);
 		});
 
 		const precipitations = [undefined, "2.51 mm"];
 		for (const [index, precipitation] of precipitations.entries()) {
 			if (precipitation) {
 				it(`should render precipitation amount ${precipitation}`, async () => {
-					const precipCell = page.locator(`.weather table tr:nth-child(${index + 1}) td.precipitation-amount`);
+					const precipCell = page.locator(`.weather .myTableClass.weather-forecast .weather-forecast-row:nth-child(${index + 1}) .precipitation-amount`);
 					await expect(precipCell).toHaveText(precipitation);
 				});
 			}
@@ -115,7 +151,7 @@ describe("Weather module: Weather Forecast", () => {
 			const temperatures = ["75_9°", "69_8°", "73_2°", "74_1°", "69_1°"];
 			for (const [index, temp] of temperatures.entries()) {
 				it(`should render custom decimalSymbol = '_' for temp ${temp}`, async () => {
-					const tempCell = page.locator(`.weather table.small tr:nth-child(${index + 1}) td.max-temp`);
+					const tempCell = page.locator(`.weather .weather-forecast-row:nth-child(${index + 1}) .max-temp`);
 					await expect(tempCell).toHaveText(temp);
 				});
 			}
@@ -126,7 +162,7 @@ describe("Weather module: Weather Forecast", () => {
 			for (const [index, precipitation] of precipitations.entries()) {
 				if (precipitation) {
 					it(`should render precipitation amount ${precipitation}`, async () => {
-						const precipCell = page.locator(`.weather table.small tr:nth-child(${index + 1}) td.precipitation-amount`);
+						const precipCell = page.locator(`.weather .weather-forecast-row:nth-child(${index + 1}) .precipitation-amount`);
 						await expect(precipCell).toHaveText(precipitation);
 					});
 				}

--- a/tests/e2e/modules/weather_hourly_spec.js
+++ b/tests/e2e/modules/weather_hourly_spec.js
@@ -18,10 +18,18 @@ describe("Weather module: Weather Hourly Forecast", () => {
 		const minTemps = ["7:00 pm", "8:00 pm", "9:00 pm", "10:00 pm", "11:00 pm"];
 		for (const [index, hour] of minTemps.entries()) {
 			it(`should render forecast for hour ${hour}`, async () => {
-				const dayCell = page.locator(`.weather table.small tr:nth-child(${index + 1}) td.day`);
-				await expect(dayCell).toHaveText(hour);
+				const timeCell = page.locator(`.weather .weather-hourly-row:nth-child(${index + 1}) .time`);
+				await expect(timeCell).toHaveText(hour);
 			});
 		}
+
+		it("should align hourly columns across rows", async () => {
+			for (const column of [".time", ".weather-icon", ".temperature"]) {
+				const firstCell = await page.locator(`.weather .weather-hourly-row:nth-child(1) ${column}`).boundingBox();
+				const secondCell = await page.locator(`.weather .weather-hourly-row:nth-child(2) ${column}`).boundingBox();
+				expect(firstCell.x).toBe(secondCell.x);
+			}
+		});
 	});
 
 	describe("Hourly weather options", () => {
@@ -34,8 +42,8 @@ describe("Weather module: Weather Hourly Forecast", () => {
 			const minTemps = ["7:00 pm", "9:00 pm", "11:00 pm", "1:00 am", "3:00 am"];
 			for (const [index, hour] of minTemps.entries()) {
 				it(`should render forecast for hour ${hour}`, async () => {
-					const dayCell = page.locator(`.weather table.small tr:nth-child(${index + 1}) td.day`);
-					await expect(dayCell).toHaveText(hour);
+					const timeCell = page.locator(`.weather .weather-hourly-row:nth-child(${index + 1}) .time`);
+					await expect(timeCell).toHaveText(hour);
 				});
 			}
 		});
@@ -52,7 +60,7 @@ describe("Weather module: Weather Hourly Forecast", () => {
 			for (const [index, amount] of amounts.entries()) {
 				if (amount) {
 					it(`should render precipitation amount ${amount}`, async () => {
-						const amountCell = page.locator(`.weather table.small tr:nth-child(${index + 1}) td.precipitation-amount`);
+						const amountCell = page.locator(`.weather .weather-hourly-row:nth-child(${index + 1}) .precipitation-amount`);
 						await expect(amountCell).toHaveText(amount);
 					});
 				}
@@ -64,10 +72,18 @@ describe("Weather module: Weather Hourly Forecast", () => {
 			for (const [index, probability] of probabilities.entries()) {
 				if (probability) {
 					it(`should render probability ${probability}`, async () => {
-						const probabilityCell = page.locator(`.weather table.small tr:nth-child(${index + 1}) td.precipitation-prob`);
+						const probabilityCell = page.locator(`.weather .weather-hourly-row:nth-child(${index + 1}) .precipitation-prob`);
 						await expect(probabilityCell).toHaveText(probability);
 					});
 				}
+			}
+		});
+
+		it("should align precipitation columns across rows", async () => {
+			for (const column of [".precipitation-amount", ".precipitation-prob"]) {
+				const firstCell = await page.locator(`.weather .weather-hourly-row:nth-child(1) ${column}`).boundingBox();
+				const fourthCell = await page.locator(`.weather .weather-hourly-row:nth-child(4) ${column}`).boundingBox();
+				expect(firstCell.x).toBe(fourthCell.x);
 			}
 		});
 	});


### PR DESCRIPTION
The daily forecast previously displayed its columns in a fixed order that did not match the order requested in the issue.

This PR makes the forecast column order configurable through CSS custom properties. The default order is now:

condition, min temp (low), max temp (high), UV Index, precipitation amount, precipitation probability

The hourly forecast is updated to use the same approach, with its own configurable column order.

- Moves `min-temp` before `max-temp` (low before high, per #4116)
- Moves UV Index block before precipitation blocks
- Adds configurable CSS ordering for forecast and hourly columns
- Replaces an invalid `<tr>` in the current weather view with a `<div>`

Fixes #4117

## forecast before
<img width="342" height="203" alt="Ekrankopio de 2026-09-12 23-48-38" src="https://github.com/user-attachments/assets/d88eb8bf-e9fa-4af1-a3ad-692fe919b956" />
<img width="599" height="210" alt="image" src="https://github.com/user-attachments/assets/030b298f-6ae3-4e40-822d-8c2eec83eca6" />


## forecast after
<img width="342" height="203" alt="Ekrankopio de 2026-09-12 23-47-47" src="https://github.com/user-attachments/assets/8e2671b5-d655-4194-89c2-8100e919a142" />
<img width="599" height="210" alt="image" src="https://github.com/user-attachments/assets/846d960e-f4b7-4c11-bad6-6160c3757ba6" />


## hourly before
<img width="214" height="209" alt="Ekrankopio de 2026-09-12 23-49-12" src="https://github.com/user-attachments/assets/bd327164-b910-4f06-97be-8b306043c9d8" />

## hourly after
<img width="214" height="209" alt="Ekrankopio de 2026-09-12 23-49-28" src="https://github.com/user-attachments/assets/356b0370-0890-46fa-9ceb-98b98a62c0dc" />

----

*Note:* The PR was updated based on reviews, and the PR text was updated accordingly.
