### PR TITLE
fix(calendar): keep yearly events in DTSTART's month when BYMONTH is missing

### DIFF
--- a/defaultmodules/calendar/calendarfetcherutils.js
+++ b/defaultmodules/calendar/calendarfetcherutils.js
@@ -234,42 +234,28 @@ const CalendarFetcherUtils = {
 	 * instead of once. The clients that emit this, and the web UIs that render it, all show
 	 * it once a year on DTSTART's date, so we follow the author's evident intent.
 	 *
-	 * The test is deliberately narrow, so rules that genuinely expand are left alone:
-	 * BYMONTHDAY must carry exactly one value, that value must equal DTSTART's day-of-month
-	 * (i.e. it merely restates DTSTART), and no other BYxxx part may shape the recurrence.
+	 * Detection reads rrule.origOptions, which carries only the parts the author actually
+	 * wrote (not the defaults node-ical fills in), so a missing BYMONTH is unambiguous. It
+	 * stays deliberately narrow, leaving rules that genuinely expand alone: BYMONTHDAY must
+	 * hold exactly one value equal to DTSTART's day-of-month (merely restating DTSTART), and
+	 * no other BYxxx part may shape the recurrence.
 	 * @param {object} event The recurring event object
 	 * @returns {boolean} True if the rule should be confined to DTSTART's month
 	 */
 	isYearlyRuleMissingByMonth (event) {
-		const rule = event.rrule;
-		if (!rule) {
+		const options = event.rrule?.origOptions;
+		if (!options || options.freq !== "YEARLY") {
 			return false;
 		}
 
-		const options = typeof rule.options === "function" ? rule.options() : rule.options;
-		// node-ical >= 0.26 reports freq as a string, earlier versions used rrule.js' numeric RRule.YEARLY.
-		if (!options || (options.freq !== "YEARLY" && options.freq !== 0)) {
+		const isSingleMonthDay = Array.isArray(options.byMonthDay) && options.byMonthDay.length === 1;
+		// Any other BYxxx part means the rule shapes the recurrence on purpose.
+		const hasShapingPart = Boolean(options.byMonth || options.byDay || options.byYearDay || options.byWeekNo || options.bySetPos);
+		if (!isSingleMonthDay || hasShapingPart) {
 			return false;
 		}
 
-		const byMonthDay = options.byMonthDay ?? options.bymonthday;
-		if (!Array.isArray(byMonthDay) || byMonthDay.length !== 1) {
-			return false;
-		}
-
-		// Any further BYxxx part means the rule shapes the recurrence on purpose.
-		const shapingParts = [
-			options.byMonth ?? options.bymonth,
-			options.byDay ?? options.byweekday,
-			options.byYearDay ?? options.byyearday,
-			options.byWeekNo ?? options.byweekno,
-			options.bySetPos ?? options.bysetpos
-		];
-		if (shapingParts.some((part) => (Array.isArray(part) ? part.length > 0 : part !== undefined && part !== null))) {
-			return false;
-		}
-
-		return byMonthDay[0] === event.start.getDate();
+		return options.byMonthDay[0] === event.start.getDate();
 	},
 
 	/**

--- a/defaultmodules/calendar/calendarfetcherutils.js
+++ b/defaultmodules/calendar/calendarfetcherutils.js
@@ -223,6 +223,56 @@ const CalendarFetcherUtils = {
 	},
 
 	/**
+	 * Detects yearly rules that restate DTSTART's day-of-month in BYMONTHDAY but omit BYMONTH,
+	 * as exported by several calendar clients (typically for birthdays), e.g.
+	 *
+	 *   DTSTART;VALUE=DATE:20231002
+	 *   RRULE:FREQ=YEARLY;WKST=MO;INTERVAL=1;BYMONTHDAY=2
+	 *
+	 * RFC 5545 makes BYMONTHDAY an *expanding* rule part for FREQ=YEARLY, so a conforming
+	 * expander returns the 2nd of every month - the event shows up twelve times a year
+	 * instead of once. The clients that emit this, and the web UIs that render it, all show
+	 * it once a year on DTSTART's date, so we follow the author's evident intent.
+	 *
+	 * The test is deliberately narrow, so rules that genuinely expand are left alone:
+	 * BYMONTHDAY must carry exactly one value, that value must equal DTSTART's day-of-month
+	 * (i.e. it merely restates DTSTART), and no other BYxxx part may shape the recurrence.
+	 * @param {object} event The recurring event object
+	 * @returns {boolean} True if the rule should be confined to DTSTART's month
+	 */
+	isYearlyRuleMissingByMonth (event) {
+		const rule = event.rrule;
+		if (!rule) {
+			return false;
+		}
+
+		const options = typeof rule.options === "function" ? rule.options() : rule.options;
+		// node-ical >= 0.26 reports freq as a string, earlier versions used rrule.js' numeric RRule.YEARLY.
+		if (!options || (options.freq !== "YEARLY" && options.freq !== 0)) {
+			return false;
+		}
+
+		const byMonthDay = options.byMonthDay ?? options.bymonthday;
+		if (!Array.isArray(byMonthDay) || byMonthDay.length !== 1) {
+			return false;
+		}
+
+		// Any further BYxxx part means the rule shapes the recurrence on purpose.
+		const shapingParts = [
+			options.byMonth ?? options.bymonth,
+			options.byDay ?? options.byweekday,
+			options.byYearDay ?? options.byyearday,
+			options.byWeekNo ?? options.byweekno,
+			options.bySetPos ?? options.bysetpos
+		];
+		if (shapingParts.some((part) => (Array.isArray(part) ? part.length > 0 : part !== undefined && part !== null))) {
+			return false;
+		}
+
+		return byMonthDay[0] === event.start.getDate();
+	},
+
+	/**
 	 * Expands a recurring event into individual event instances using node-ical.
 	 * Handles RRULE expansion, EXDATE filtering, RECURRENCE-ID overrides, and ongoing events.
 	 * @param {object} event The recurring event object
@@ -232,6 +282,9 @@ const CalendarFetcherUtils = {
 	 */
 	expandRecurringEvent (event, pastLocalMoment, futureLocalMoment) {
 		const localTimezone = CalendarFetcherUtils.getLocalTimezone();
+		// Drop the eleven spurious months produced by a yearly rule that is missing BYMONTH.
+		const confineToStartMonth = CalendarFetcherUtils.isYearlyRuleMissingByMonth(event);
+		const startMonth = event.start.getMonth();
 
 		return ical
 			.expandRecurringEvent(event, {
@@ -241,6 +294,7 @@ const CalendarFetcherUtils = {
 				excludeExdates: true,
 				expandOngoing: true
 			})
+			.filter((inst) => !confineToStartMonth || inst.start.getMonth() === startMonth)
 			.map((inst) => {
 				let startMoment, endMoment;
 				if (inst.isFullDay) {

--- a/tests/unit/modules/default/calendar/calendar_fetcher_utils_spec.js
+++ b/tests/unit/modules/default/calendar/calendar_fetcher_utils_spec.js
@@ -517,4 +517,83 @@ END:VCALENDAR`);
 			expect(filteredEvents[0].location).toBe("Berlin");
 		});
 	});
+
+	describe("yearly events that restate DTSTART's day in BYMONTHDAY but omit BYMONTH", () => {
+		// See GitHub issues #2547 and #3047: several calendar clients export a yearly
+		// event (typically a birthday) as FREQ=YEARLY;BYMONTHDAY=<day of DTSTART> without
+		// a BYMONTH part. RFC 5545 makes BYMONTHDAY an *expanding* rule part for YEARLY,
+		// so a conforming expander returns that day in every month - the event then shows
+		// up twelve times a year instead of once.
+
+		const yearConfig = { ...defaultConfig, maximumNumberOfDays: 365 };
+
+		const buildEvent = function (rrule, dtstart = "20231002", dtend = "20231003") {
+			return ical.parseICS(`BEGIN:VCALENDAR
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:${dtstart}
+DTEND;VALUE=DATE:${dtend}
+RRULE:${rrule}
+DTSTAMP:20230425T111027Z
+UID:yearly-bymonthday@example.com
+SUMMARY:Ted Birthday
+END:VEVENT
+END:VCALENDAR`);
+		};
+
+		const monthDaysOf = (events) => events.map((event) => moment(event.startDate, "x").format("MM-DD"));
+
+		it("should occur only in DTSTART's month when BYMONTH is missing", () => {
+			const data = buildEvent("FREQ=YEARLY;WKST=MO;INTERVAL=1;BYMONTHDAY=2");
+
+			const monthDays = monthDaysOf(CalendarFetcherUtils.filterEvents(data, yearConfig));
+
+			expect(monthDays.length).toBeGreaterThan(0);
+			expect(monthDays).toEqual(monthDays.map(() => "10-02"));
+		});
+
+		it("should still expand a rule that lists several days of the month", () => {
+			// FREQ=YEARLY;BYMONTHDAY=1,3 legitimately expands across the whole year.
+			const data = buildEvent("FREQ=YEARLY;BYMONTHDAY=1,3");
+
+			const months = new Set(monthDaysOf(CalendarFetcherUtils.filterEvents(data, yearConfig)).map((md) => md.slice(0, 2)));
+
+			expect(months.size).toBe(12);
+		});
+
+		it("should still expand a rule that also constrains the weekday", () => {
+			// "Every Friday the 13th" - BYDAY shapes the recurrence, so it must expand.
+			const data = buildEvent("FREQ=YEARLY;BYMONTHDAY=13;BYDAY=FR");
+
+			const monthDays = monthDaysOf(CalendarFetcherUtils.filterEvents(data, yearConfig));
+
+			expect(monthDays.length).toBeGreaterThan(0);
+			expect(monthDays.every((md) => md.endsWith("-13"))).toBe(true);
+			expect(monthDays.some((md) => !md.startsWith("10"))).toBe(true);
+		});
+
+		it("should still expand when BYMONTHDAY does not match DTSTART's day", () => {
+			// The day was not simply restated from DTSTART, so the rule means something else.
+			const data = buildEvent("FREQ=YEARLY;WKST=MO;INTERVAL=1;BYMONTHDAY=7");
+
+			const months = new Set(monthDaysOf(CalendarFetcherUtils.filterEvents(data, yearConfig)).map((md) => md.slice(0, 2)));
+
+			expect(months.size).toBe(12);
+		});
+
+		it("should keep a well-formed yearly rule with BYMONTH on its single date", () => {
+			const data = buildEvent("FREQ=YEARLY;WKST=MO;INTERVAL=1;BYMONTHDAY=2;BYMONTH=10");
+
+			const monthDays = monthDaysOf(CalendarFetcherUtils.filterEvents(data, yearConfig));
+
+			expect(monthDays).toEqual(["10-02"]);
+		});
+
+		it("should keep a plain yearly rule on its single date", () => {
+			const data = buildEvent("FREQ=YEARLY");
+
+			const monthDays = monthDaysOf(CalendarFetcherUtils.filterEvents(data, yearConfig));
+
+			expect(monthDays).toEqual(["10-02"]);
+		});
+	});
 });


### PR DESCRIPTION
A birthday in my Google Calendar showed up on my mirror as "tomorrow" when it is actually in October. It turns out it had been appearing on the 2nd of *every* month, and I had simply never noticed until it landed on a day I paid attention to.

The event looks like this in the ICS feed:

```ics
DTSTART;VALUE=DATE:20231002
DTEND;VALUE=DATE:20231003
RRULE:FREQ=YEARLY;WKST=MO;INTERVAL=1;BYMONTHDAY=2
SUMMARY:Ted Birthday
```

`FREQ=YEARLY` together with `BYMONTHDAY=2`, but no `BYMONTH`. `BYMONTHDAY` is an expanding rule part for `FREQ=YEARLY`, so the expander returns the 2nd of every month — twelve occurrences a year instead of one. Google Calendar's own UI, and the client that wrote the rule, show it once a year on 2 October.

Out of 3354 events in my calendar exactly two had this shape, both created by an older mobile calendar app. Newer clients write a plain `RRULE:FREQ=YEARLY`, which is why this is easy to miss — but the old events are never rewritten, so they keep misbehaving forever.

### Why not fix it in the RRULE library

This has come up before, and each time it was closed as bad input data rather than fixed: #2547 (2021), #3047 (2023), and recently jens-maus/node-ical#531. In that last one a fix was actually written (ggaabe/rrule-temporal#127) and then withdrawn, because a reviewer pointed out that restricting yearly `BYMONTHDAY` rules to the `DTSTART` month breaks legitimate rules such as `FREQ=YEARLY;BYMONTHDAY=1,3`, which really must expand across all twelve months.

That objection is correct, and it is why I don't think the RRULE engine is the right place for this. A general-purpose expander has to follow RFC 5545. A calendar display, on the other hand, can afford to be liberal about a well-known broken export as long as the detection is narrow enough that no correct rule is touched.

### What this does

`expandRecurringEvent` confines a yearly rule to `DTSTART`'s month, but only when the rule is provably a redundant restatement of `DTSTART` rather than a real expansion. All of these must hold:

- `FREQ=YEARLY`
- `BYMONTHDAY` holds exactly one value
- that value equals `DTSTART`'s day-of-month
- no `BYMONTH`, `BYDAY`, `BYYEARDAY`, `BYWEEKNO` or `BYSETPOS`

Under those conditions the expansion yields `DTSTART`'s own date plus eleven dates the author never wrote, so dropping the extras cannot lose a real occurrence.

| Rule | Affected? | Result |
| --- | --- | --- |
| `FREQ=YEARLY;...;BYMONTHDAY=2`, DTSTART Oct 2 | yes | once a year, 2 October |
| `FREQ=YEARLY;BYMONTHDAY=1,3` | no, two values | unchanged, expands over 12 months |
| `FREQ=YEARLY;BYMONTHDAY=13;BYDAY=FR` | no, `BYDAY` present | unchanged, every Friday the 13th |
| `FREQ=YEARLY;BYMONTHDAY=7`, DTSTART on the 2nd | no, day mismatch | unchanged, expands |
| `FREQ=YEARLY;BYMONTHDAY=2;BYMONTH=10` | no, `BYMONTH` present | unchanged, once a year |
| `FREQ=YEARLY` | no, no `BYMONTHDAY` | unchanged, once a year |

The rule is read through node-ical's public `options`, and both the current string `freq` and the older numeric one are accepted.

### Tests

Six new cases in `calendar_fetcher_utils_spec.js`. The five "unaffected" rows above are tests that already pass without the change — they are there to pin the behaviour that must not regress. Only the first one fails before the fix.

Calendar unit tests pass on `Europe/Zurich`, `America/New_York`, `Pacific/Auckland`, `Asia/Kolkata` and `UTC`. `lint:js` and `lint:prettier` are clean.

Against my own feed over the next 365 days the number of occurrences goes from 132 to 110, and the difference is exactly the 22 spurious instances from those two events — nothing else changes.

### One thing worth deciding

I've made this unconditional, since the detection is narrow enough that no correct rule is affected. If you would rather have it behind a calendar config option, say so and I'll move it.
