### PR TITLE
ci: fail lint on warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"test:coverage": "vitest run --coverage",
 		"test:e2e": "vitest run tests/e2e",
 		"test:electron": "vitest run tests/electron",
-		"test:lint": "eslint && prettier . --check",
+		"test:lint": "eslint --max-warnings=0 && prettier . --check",
 		"test:spelling": "cspell . --gitignore",
 		"test:ui": "vitest --ui",
 		"test:unit": "vitest run tests/unit",


### PR DESCRIPTION
With this the lint check now fails when ESLint reports warnings, so issues like those seen in #4228 can no longer leave the CI pipeline green.