### PR TITLE
remove codeql warning

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -29,6 +29,9 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
+          config: |
+            paths-ignore:
+              - tests/configs/config_variables.js
 
       - uses: github/codeql-action/autobuild@v4
 


### PR DESCRIPTION
Excluding the file `tests/configs/config_variables.js` from codeql to get rid of the warning below.
The file contains the line `timeFormat: ${MM_TIME_FORMAT},` which is no valid js syntax.

<img width="1757" height="947" alt="image" src="https://github.com/user-attachments/assets/6bd22304-d8e5-4fd0-a609-6ec1fe265a24" />
