### PR TITLE
Fix calendar crash when yearmatchgroup regex does not match

### DIFF
--- a/defaultmodules/calendar/calendarutils.js
+++ b/defaultmodules/calendar/calendarutils.js
@@ -109,7 +109,7 @@ const CalendarUtils = {
 					let replacement = transform.replace;
 					if (typeof transform.yearmatchgroup !== "undefined" && transform.yearmatchgroup !== "") {
 						const yearmatch = [...title.matchAll(needle)];
-						if (yearmatch[0].length >= transform.yearmatchgroup + 1 && yearmatch[0][transform.yearmatchgroup] * 1 >= 1900) {
+						if (yearmatch.length > 0 && yearmatch[0].length >= transform.yearmatchgroup + 1 && yearmatch[0][transform.yearmatchgroup] * 1 >= 1900) {
 							const calcage = new Date().getFullYear() - yearmatch[0][transform.yearmatchgroup] * 1;
 							const searchstr = `$${transform.yearmatchgroup}`;
 							replacement = replacement.replace(searchstr, calcage);

--- a/tests/unit/modules/default/calendar/calendar_utils_spec.js
+++ b/tests/unit/modules/default/calendar/calendar_utils_spec.js
@@ -151,5 +151,10 @@ describe("Calendar utils tests", () => {
 			const expectedResult = `Luciella (${new Date().getFullYear() - 2000}.)`;
 			expect(transformedTitle).toBe(expectedResult);
 		});
+
+		it("should not fail when the yearmatchgroup regex does not match", () => {
+			const transformedTitle = CalendarUtils.titleTransform("Test Birthday", [{ search: "^(.+) \\((\\d{4})\\)$", replace: "$1 ($2)", yearmatchgroup: 2 }]);
+			expect(transformedTitle).toBe("Test Birthday");
+		});
 	});
 });


### PR DESCRIPTION
# Description
Fixes an issue in CalendarUtils.titleTransform() when a title transformation uses yearmatchgroup but the configured regular expression does not match the event title.

Currently, matchAll() returns an empty array when there is no match, but the code subsequently accesses yearmatch[0].length. This results in an exception and causes the calendar module to stop displaying its events.

This can occur when using yearmatchgroup for birthday events, for example, when some matching events have a birth year in the expected format while another event matching the keyword does not.

# Change
Check that yearmatch contains at least one match before accessing yearmatch[0].

This is a one-line change and leaves the existing behaviour unchanged when the regular expression matches.

# Example
With a transformation such as:
```
transform: {
    search: "^(.+) \\((\\d{4})\\)$",
    replace: "$1 ($2)",
    yearmatchgroup: 2
}
```
an event such as:
```
Test Birthday (1987)
```
continues to be transformed to:
```
Test Birthday (39)
```
while an event matching the custom-event keyword but not the year pattern no longer causes the calendar module to fail.