### PR TITLE
refactor(utils): simplify configuration validation and error handling

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -255,10 +255,11 @@ function App () {
 			Log.log("Sockets connected & modules started ...");
 
 			return global.config;
-		} catch (err) {
-			// planned ConfigErrors already logged their message before throwing
-			if (!(err instanceof ConfigError)) {
-				Log.error("Unexpected error during startup:", err);
+		} catch (error) {
+			if (error instanceof ConfigError) {
+				Log.error(error.message);
+			} else {
+				Log.error("Unexpected error during startup:", error);
 			}
 
 			const int32 = new Int32Array(new SharedArrayBuffer(4));

--- a/js/check_config.js
+++ b/js/check_config.js
@@ -10,7 +10,11 @@ const Utils = require(`${rootPath}/js/utils.js`);
 try {
 	Utils.checkConfigFile();
 } catch (error) {
-	const message = error && error.message ? error.message : error;
-	Log.error(`Unexpected error: ${message}`);
+	if (error instanceof Utils.ConfigError) {
+		Log.error(error.message);
+	} else {
+		const message = error && error.message ? error.message : error;
+		Log.error(`Unexpected error: ${message}`);
+	}
 	process.exit(1);
 }

--- a/js/utils.js
+++ b/js/utils.js
@@ -184,22 +184,14 @@ const loadConfig = () => {
 };
 
 /**
- * Checks the config file using eslint.
- * @param {object} configObject the configuration object
+ * Runs the ESLint checks configured for the config file.
+ * @param {string} configFileName - The filename shown in lint messages.
+ * @param {string} configFileContent - The config file content to lint.
+ * @returns {Array<object>} ESLint messages for linting problems.
  */
-const checkConfigFile = (configObject) => {
-	let configObj = configObject;
-	if (!configObj) configObj = loadConfig();
-	const configFileName = configObj.configFilename;
-
-	// Validate syntax of the configuration file.
-	Log.info(`Checking config file ${configFileName} ...`);
-
-	// I'm not sure if all ever is utf-8
-	const configFile = configObj.configContentFull;
-
-	const errors = linter.verify(
-		configFile,
+function lintConfigFile (configFileName, configFileContent) {
+	return linter.verify(
+		configFileContent,
 		{
 			languageOptions: {
 				ecmaVersion: "latest",
@@ -215,20 +207,22 @@ const checkConfigFile = (configObject) => {
 		},
 		configFileName
 	);
+}
 
-	if (errors.length === 0) {
-		Log.info(styleText("green", "Your configuration file doesn't contain syntax errors :)"));
-		validateModulePositions(configObj.fullConf);
-	} else {
-		let errorMessage = "Your configuration file contains syntax errors :(";
+/**
+ * Formats ESLint messages for the config syntax error output.
+ * @param {Array<object>} errors - ESLint messages returned by `linter.verify`.
+ * @returns {string} A user-facing error message.
+ */
+function formatConfigSyntaxErrors (errors) {
+	let errorMessage = "Your configuration file contains syntax errors :(";
 
-		for (const error of errors) {
-			errorMessage += `\nLine ${error.line} column ${error.column}: ${error.message}`;
-		}
-		Log.error(errorMessage);
-		throw new ConfigError("");
+	for (const error of errors) {
+		errorMessage += `\nLine ${error.line} column ${error.column}: ${error.message}`;
 	}
-};
+
+	return errorMessage;
+}
 
 /**
  * Validates the modules array in the config object.
@@ -237,38 +231,44 @@ const checkConfigFile = (configObject) => {
  *  - every entry has a `module` property of type string
  *  - every entry's `position` (if set) is a known region from index.html
  *
- * Unknown positions produce a warning; structural errors are fatal.
+ * Unknown positions produce a warning; structural errors throw an error so the
+ * outer validation flow can decide how to report and terminate.
  * @param {object} data - The full config object to validate.
+ * @throws {Error} When the modules structure is invalid.
  */
-const validateModulePositions = (data) => {
+function validateModulePositions (data) {
 	Log.info("Checking modules structure configuration ...");
 
 	const positionList = getModulePositions();
 
 	// `modules` always exists (defaults.js provides a default array), but guard against it being overridden with a non-array value
 	if (data.modules !== undefined && !Array.isArray(data.modules)) {
-		Log.error("This module configuration contains errors:\nmodules must be an array");
-		throw new ConfigError("");
+		const errorMessage = "This module configuration contains errors:\nmodules must be an array";
+		Log.error(errorMessage);
+		throw new ConfigError(errorMessage);
 	}
 
 	// Validate each module entry
 	for (const [index, mod] of (data.modules ?? []).entries()) {
 		// Each module entry must be an object so we can safely inspect its fields
 		if (mod === null || typeof mod !== "object" || Array.isArray(mod)) {
-			Log.error(`This module configuration contains errors:\n${JSON.stringify(mod, null, 2)}\nmodule entry must be an object`);
-			throw new ConfigError("");
+			const errorMessage = `This module configuration contains errors:\n${JSON.stringify(mod, null, 2)}\nmodule entry must be an object`;
+			Log.error(errorMessage);
+			throw new ConfigError(errorMessage);
 		}
 
 		// `module` (the module name) is required and must be a string
 		if (typeof mod.module !== "string") {
-			Log.error(`This module configuration contains errors:\n${JSON.stringify(mod, null, 2)}\nmodule: must be a string`);
-			throw new ConfigError("");
+			const errorMessage = `This module configuration contains errors:\n${JSON.stringify(mod, null, 2)}\nmodule: must be a string`;
+			Log.error(errorMessage);
+			throw new ConfigError(errorMessage);
 		}
 
 		// `position` is optional, but must be a string when provided
 		if (mod.position !== undefined && typeof mod.position !== "string") {
-			Log.error(`This module configuration contains errors:\n${JSON.stringify(mod, null, 2)}\nposition: must be a string`);
-			throw new ConfigError("");
+			const errorMessage = `This module configuration contains errors:\n${JSON.stringify(mod, null, 2)}\nposition: must be a string`;
+			Log.error(errorMessage);
+			throw new ConfigError(errorMessage);
 		}
 
 		// `position` is optional, but when set it must match a known region
@@ -279,6 +279,32 @@ const validateModulePositions = (data) => {
 	}
 
 	Log.info(styleText("green", "Your modules structure configuration doesn't contain errors :)"));
-};
+}
+
+/**
+ * Checks the config file by orchestrating syntax and structure validation.
+ *
+ * Syntax errors and invalid module structures are fatal. Unknown module
+ * positions remain warnings only.
+ * @param {object} [configObject] - The loaded config object. When omitted, the config is loaded first.
+ */
+function checkConfigFile (configObject) {
+	let configObj = configObject;
+	if (!configObj) configObj = loadConfig();
+	const configFileName = configObj.configFilename;
+
+	// Validate syntax of the configuration file first.
+	Log.info(`Checking config file ${configFileName} ...`);
+
+	const errors = lintConfigFile(configFileName, configObj.configContentFull);
+
+	if (errors.length === 0) {
+		Log.info(styleText("green", "Your configuration file doesn't contain syntax errors :)"));
+		validateModulePositions(configObj.fullConf);
+	} else {
+		Log.error(formatConfigSyntaxErrors(errors));
+		throw new ConfigError("");
+	}
+}
 
 module.exports = { loadConfig, getModulePositions, moduleHasValidPosition, getAvailableModulePositions, checkConfigFile, ConfigError };

--- a/js/utils.js
+++ b/js/utils.js
@@ -21,23 +21,38 @@ class ConfigError extends Error {
 	}
 }
 
+/**
+ * Executes CommonJS source code from a string and returns its exports.
+ * @param {string} src - JavaScript source code.
+ * @returns {object} The exported module value.
+ */
 const requireFromString = (src) => {
 	const m = new module.constructor();
 	m._compile(src, "");
 	return m.exports;
 };
 
-// return all available module positions
+/**
+ * Returns all discovered module positions.
+ * @returns {Array<string>} Known module positions.
+ */
 const getAvailableModulePositions = () => {
 	return modulePositions;
 };
 
-// return if position is on modulePositions Array (true/false)
+/**
+ * Checks whether the provided module position exists.
+ * @param {string} position - Candidate module position.
+ * @returns {boolean} True when the position is known.
+ */
 const moduleHasValidPosition = (position) => {
-	if (getAvailableModulePositions().indexOf(position) === -1) return false;
-	return true;
+	return getAvailableModulePositions().includes(position);
 };
 
+/**
+ * Discovers module positions from index.html and caches them.
+ * @returns {Array<string>} Discovered module positions.
+ */
 const getModulePositions = () => {
 	// if not already discovered
 	if (modulePositions.length === 0) {
@@ -172,14 +187,13 @@ const loadConfig = () => {
 		return configObj;
 
 	} catch (error) {
+		let errorMessage = `Cannot access config file: ${configFilename}\n${error.message}`;
 		if (error.code === "ENOENT") {
-			Log.error(`Could not find config file: ${configFilename}`);
+			errorMessage = `Could not find config file: ${configFilename}`;
 		} else if (error.code === "EACCES") {
-			Log.error(`No permission to read config file: ${configFilename}`);
-		} else {
-			Log.error(`Cannot access config file: ${configFilename}\n${error.message}`);
+			errorMessage = `No permission to read config file: ${configFilename}`;
 		}
-		throw new ConfigError("");
+		throw new ConfigError(errorMessage);
 	}
 };
 
@@ -189,7 +203,7 @@ const loadConfig = () => {
  * @param {string} configFileContent - The config file content to lint.
  * @returns {Array<object>} ESLint messages for linting problems.
  */
-function lintConfigFile (configFileName, configFileContent) {
+const lintConfigFile = (configFileName, configFileContent) => {
 	return linter.verify(
 		configFileContent,
 		{
@@ -207,14 +221,14 @@ function lintConfigFile (configFileName, configFileContent) {
 		},
 		configFileName
 	);
-}
+};
 
 /**
  * Formats ESLint messages for the config syntax error output.
  * @param {Array<object>} errors - ESLint messages returned by `linter.verify`.
  * @returns {string} A user-facing error message.
  */
-function formatConfigSyntaxErrors (errors) {
+const formatConfigSyntaxErrors = (errors) => {
 	let errorMessage = "Your configuration file contains syntax errors :(";
 
 	for (const error of errors) {
@@ -222,7 +236,7 @@ function formatConfigSyntaxErrors (errors) {
 	}
 
 	return errorMessage;
-}
+};
 
 /**
  * Validates the modules array in the config object.
@@ -234,41 +248,33 @@ function formatConfigSyntaxErrors (errors) {
  * Unknown positions produce a warning; structural errors throw an error so the
  * outer validation flow can decide how to report and terminate.
  * @param {object} data - The full config object to validate.
- * @throws {Error} When the modules structure is invalid.
+ * @throws {ConfigError} When the modules structure is invalid.
  */
-function validateModulePositions (data) {
+const validateModulePositions = (data) => {
 	Log.info("Checking modules structure configuration ...");
 
 	const positionList = getModulePositions();
 
 	// `modules` always exists (defaults.js provides a default array), but guard against it being overridden with a non-array value
 	if (data.modules !== undefined && !Array.isArray(data.modules)) {
-		const errorMessage = "This module configuration contains errors:\nmodules must be an array";
-		Log.error(errorMessage);
-		throw new ConfigError(errorMessage);
+		throw new ConfigError("This module configuration contains errors:\nmodules must be an array");
 	}
 
 	// Validate each module entry
 	for (const [index, mod] of (data.modules ?? []).entries()) {
 		// Each module entry must be an object so we can safely inspect its fields
 		if (mod === null || typeof mod !== "object" || Array.isArray(mod)) {
-			const errorMessage = `This module configuration contains errors:\n${JSON.stringify(mod, null, 2)}\nmodule entry must be an object`;
-			Log.error(errorMessage);
-			throw new ConfigError(errorMessage);
+			throw new ConfigError(`This module configuration contains errors:\n${JSON.stringify(mod, null, 2)}\nmodule entry must be an object`);
 		}
 
 		// `module` (the module name) is required and must be a string
 		if (typeof mod.module !== "string") {
-			const errorMessage = `This module configuration contains errors:\n${JSON.stringify(mod, null, 2)}\nmodule: must be a string`;
-			Log.error(errorMessage);
-			throw new ConfigError(errorMessage);
+			throw new ConfigError(`This module configuration contains errors:\n${JSON.stringify(mod, null, 2)}\nmodule: must be a string`);
 		}
 
 		// `position` is optional, but must be a string when provided
 		if (mod.position !== undefined && typeof mod.position !== "string") {
-			const errorMessage = `This module configuration contains errors:\n${JSON.stringify(mod, null, 2)}\nposition: must be a string`;
-			Log.error(errorMessage);
-			throw new ConfigError(errorMessage);
+			throw new ConfigError(`This module configuration contains errors:\n${JSON.stringify(mod, null, 2)}\nposition: must be a string`);
 		}
 
 		// `position` is optional, but when set it must match a known region
@@ -279,7 +285,7 @@ function validateModulePositions (data) {
 	}
 
 	Log.info(styleText("green", "Your modules structure configuration doesn't contain errors :)"));
-}
+};
 
 /**
  * Checks the config file by orchestrating syntax and structure validation.
@@ -287,8 +293,9 @@ function validateModulePositions (data) {
  * Syntax errors and invalid module structures are fatal. Unknown module
  * positions remain warnings only.
  * @param {object} [configObject] - The loaded config object. When omitted, the config is loaded first.
+ * @throws {ConfigError} When the configuration contains fatal errors.
  */
-function checkConfigFile (configObject) {
+const checkConfigFile = (configObject) => {
 	let configObj = configObject;
 	if (!configObj) configObj = loadConfig();
 	const configFileName = configObj.configFilename;
@@ -302,9 +309,8 @@ function checkConfigFile (configObject) {
 		Log.info(styleText("green", "Your configuration file doesn't contain syntax errors :)"));
 		validateModulePositions(configObj.fullConf);
 	} else {
-		Log.error(formatConfigSyntaxErrors(errors));
-		throw new ConfigError("");
+		throw new ConfigError(formatConfigSyntaxErrors(errors));
 	}
-}
+};
 
-module.exports = { loadConfig, getModulePositions, moduleHasValidPosition, getAvailableModulePositions, checkConfigFile, ConfigError };
+module.exports = { loadConfig, getModulePositions, moduleHasValidPosition, checkConfigFile, ConfigError };

--- a/js/utils.js
+++ b/js/utils.js
@@ -33,20 +33,12 @@ const requireFromString = (src) => {
 };
 
 /**
- * Returns all discovered module positions.
- * @returns {Array<string>} Known module positions.
- */
-const getAvailableModulePositions = () => {
-	return modulePositions;
-};
-
-/**
  * Checks whether the provided module position exists.
  * @param {string} position - Candidate module position.
  * @returns {boolean} True when the position is known.
  */
 const moduleHasValidPosition = (position) => {
-	return getAvailableModulePositions().includes(position);
+	return getModulePositions().includes(position);
 };
 
 /**

--- a/tests/unit/classes/utils_spec.js
+++ b/tests/unit/classes/utils_spec.js
@@ -13,14 +13,11 @@ const runCheck = (modules) => {
 	checkConfigFile(createConfigObject(modules));
 };
 
-const expectExitForModules = (modules) => {
-	vi.spyOn(process, "exit").mockImplementation(() => {
-		throw new ConfigError("");
-	});
-
+const expectConfigErrorForModules = (modules) => {
 	expect(() => {
 		runCheck(modules);
 	}).toThrow(ConfigError);
+	expect(process.exit).not.toHaveBeenCalled();
 };
 
 describe("utils", () => {
@@ -41,6 +38,7 @@ describe("utils", () => {
 		vi.spyOn(Log, "info").mockImplementation(() => {});
 		vi.spyOn(Log, "warn").mockImplementation(() => {});
 		vi.spyOn(Log, "error").mockImplementation(() => {});
+		vi.spyOn(process, "exit").mockImplementation(() => {});
 	});
 
 	afterEach(() => {
@@ -57,13 +55,13 @@ describe("utils", () => {
 		expect(Log.error).not.toHaveBeenCalled();
 	});
 
-	it("exits when modules is not an array", () => {
-		expectExitForModules("not-an-array");
+	it("throws when modules is not an array", () => {
+		expectConfigErrorForModules("not-an-array");
 		expect(Log.error).toHaveBeenCalledWith("This module configuration contains errors:\nmodules must be an array");
 	});
 
-	it("exits when module field is missing or not a string", () => {
-		expectExitForModules([{ module: 123, position: "top_bar" }]);
+	it("throws when module field is missing or not a string", () => {
+		expectConfigErrorForModules([{ module: 123, position: "top_bar" }]);
 		expect(Log.error).toHaveBeenCalled();
 		expect(Log.error.mock.calls[0][0]).toContain("module: must be a string");
 	});

--- a/tests/unit/classes/utils_spec.js
+++ b/tests/unit/classes/utils_spec.js
@@ -3,14 +3,14 @@ const fs = require("node:fs");
 const Log = require("../../../js/logger");
 const { checkConfigFile, ConfigError } = require("../../../js/utils");
 
-const createConfigObject = (modules) => ({
+const createConfigObject = (modules, configContentFull = "module.exports = { modules: [] };") => ({
 	configFilename: "config.js",
-	configContentFull: "module.exports = { modules: [] };",
+	configContentFull,
 	fullConf: { modules }
 });
 
-const runCheck = (modules) => {
-	checkConfigFile(createConfigObject(modules));
+const runCheck = (modules, configContentFull) => {
+	checkConfigFile(createConfigObject(modules, configContentFull));
 };
 
 const expectConfigErrorForModules = (modules) => {
@@ -57,25 +57,27 @@ describe("utils", () => {
 
 	it("throws when modules is not an array", () => {
 		expectConfigErrorForModules("not-an-array");
-		expect(Log.error).toHaveBeenCalledWith("This module configuration contains errors:\nmodules must be an array");
+		expect(Log.error).not.toHaveBeenCalled();
 	});
 
 	it("throws when module field is missing or not a string", () => {
 		expectConfigErrorForModules([{ module: 123, position: "top_bar" }]);
-		expect(Log.error).toHaveBeenCalled();
-		expect(Log.error.mock.calls[0][0]).toContain("module: must be a string");
+		expect(Log.error).not.toHaveBeenCalled();
 	});
 
 	it("warns for unknown positions without exiting", () => {
-		const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
-			throw new ConfigError("");
-		});
-
 		expect(() => {
 			runCheck([{ module: "clock", position: "made_up_region" }]);
 		}).not.toThrow();
-		expect(exitSpy).not.toHaveBeenCalled();
+		expect(process.exit).not.toHaveBeenCalled();
 		expect(Log.warn).toHaveBeenCalled();
 		expect(Log.warn.mock.calls[0][0]).toContain("uses unknown position");
+	});
+
+	it("throws syntax errors with their lint details", () => {
+		expect(() => {
+			runCheck([], "module.exports = { modules: [ };");
+		}).toThrow(/Your configuration file contains syntax errors/);
+		expect(process.exit).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
I ended up going down a bit of a rabbit hole with this PR. The main goal throughout was to make the code easier to understand and maintain. There are no intended changes to the normal application behavior. The error handling is also more consistent now, with error messages being passed to the point where they are handled instead of being logged in multiple places.

Please let me know if the PR has grown too large or if I have taken things in a direction that would be worth discussing :slightly_smiling_face: 

**Commit 1**

I started by looking at `checkConfigFile` and felt that it was doing too many different things. I split its responsibilities into a few smaller functions to make the overall flow easier to follow.

Outcome: clearer responsibilities and a simpler configuration validation flow.

**Commit 2** (edited)

After your review comment, I decided to undo the arrow-function replacement but keep the documentation improvements instead.

Outcome: clearer JSDoc documentation while keeping the existing function style consistent with the rest of the project.

**Commit 3**

Finally, I noticed that some validation paths were throwing errors without any message:

```js
throw new ConfigError("");
```

An error without a message is not very helpful for debugging. This led me to move the error logging to the places where the errors are handled and to make sure that every `ConfigError` carries a useful message.

Outcome: more consistent error handling and cleaner error output.

**Commit 4**

After looking at the remaining usages, I noticed that `getAvailableModulePositions` was only a thin wrapper around the internal `modulePositions` array. It's not part of the documented API for third-party modules, so I removed it and let `moduleHasValidPosition` use `getModulePositions` directly.

Outcome: less indirection and a smaller internal API, without changing the intended behavior.