### PR TITLE
refactor(eslint): enforce prefer-arrow-callback rule

### DIFF
--- a/clientonly/index.js
+++ b/clientonly/index.js
@@ -50,11 +50,11 @@ function getServerConfig (url) {
 			let configData = "";
 
 			// Gather incoming data
-			response.on("data", function (chunk) {
+			response.on("data", (chunk) => {
 				configData += chunk;
 			});
 			// Resolve promise at the end of the HTTP/HTTPS stream
-			response.on("end", function () {
+			response.on("end", () => {
 				try {
 					resolve(JSON.parse(configData));
 				} catch (parseError) {
@@ -63,7 +63,7 @@ function getServerConfig (url) {
 			});
 		});
 
-		request.on("error", function (error) {
+		request.on("error", (error) => {
 			reject(new Error(`Unable to read config from server (${url}) (${error.message})`));
 		});
 	});
@@ -122,16 +122,16 @@ async function startClient (config, prefix) {
 		const child = require("node:child_process").spawn(electron, elecParams, options);
 
 		// Pipe all child process output to current stdout
-		child.stdout.on("data", function (buf) {
+		child.stdout.on("data", (buf) => {
 			process.stdout.write(`Client: ${buf}`);
 		});
 
 		// Pipe all child process errors to current stderr
-		child.stderr.on("data", function (buf) {
+		child.stderr.on("data", (buf) => {
 			process.stderr.write(`Client: ${buf}`);
 		});
 
-		child.on("error", function (err) {
+		child.on("error", (err) => {
 			process.stderr.write(`Client: ${err}`);
 		});
 

--- a/defaultmodules/alert/alert.js
+++ b/defaultmodules/alert/alert.js
@@ -124,7 +124,7 @@ Module.register("alert", {
 
 	renderMessage (type, data) {
 		return new Promise((resolve) => {
-			this.nunjucksEnvironment().render(this.getTemplate(type), data, function (err, res) {
+			this.nunjucksEnvironment().render(this.getTemplate(type), data, (err, res) => {
 				if (err) {
 					Log.error("[alert] Failed to render alert", err);
 				}

--- a/defaultmodules/calendar/calendar.js
+++ b/defaultmodules/calendar/calendar.js
@@ -559,7 +559,7 @@ Module.register("calendar", {
 			}
 			if (limitNumberOfEntries) {
 				// sort entries before clipping
-				by_url_calevents.sort(function (a, b) {
+				by_url_calevents.sort((a, b) => {
 					return a.startDate - b.startDate;
 				});
 				Log.debug(`[calendar] pushing ${by_url_calevents.length} events to total with room for ${remainingEntries}`);
@@ -570,7 +570,7 @@ Module.register("calendar", {
 			}
 		}
 		Log.info(`[calendar] sorting events count=${events.length}`);
-		events.sort(function (a, b) {
+		events.sort((a, b) => {
 			return a.startDate - b.startDate;
 		});
 
@@ -674,7 +674,7 @@ Module.register("calendar", {
 
 	mergeUnique (arr1, arr2) {
 		return arr1.concat(
-			arr2.filter(function (item) {
+			arr2.filter((item) => {
 				return arr1.indexOf(item) === -1;
 			})
 		);

--- a/defaultmodules/calendar/calendarfetcherutils.js
+++ b/defaultmodules/calendar/calendarfetcherutils.js
@@ -150,7 +150,7 @@ const CalendarFetcherUtils = {
 			}
 		});
 
-		newEvents.sort(function (a, b) {
+		newEvents.sort((a, b) => {
 			return a.startDate - b.startDate;
 		});
 

--- a/defaultmodules/calendar/debug.js
+++ b/defaultmodules/calendar/debug.js
@@ -25,12 +25,12 @@ Log.log("Create fetcher ...");
 
 const fetcher = new CalendarFetcher(url, fetchInterval, [], maximumEntries, maximumNumberOfDays, auth);
 
-fetcher.onReceive(function (fetcher) {
+fetcher.onReceive((fetcher) => {
 	Log.log(fetcher.events);
 	process.exit(0);
 });
 
-fetcher.onError(function (fetcher, error) {
+fetcher.onError((fetcher, error) => {
 	Log.log("Fetcher error:", error);
 	process.exit(1);
 });

--- a/defaultmodules/newsfeed/newsfeed.js
+++ b/defaultmodules/newsfeed/newsfeed.js
@@ -182,7 +182,7 @@ Module.register("newsfeed", {
 		const item = this.newsItems[this.activeItem];
 		this.activeItemHash = item.hash;
 
-		const items = this.newsItems.map(function (item) {
+		const items = this.newsItems.map((item) => {
 			item.publishDate = moment(new Date(item.pubdate)).fromNow();
 			return item;
 		});
@@ -250,7 +250,7 @@ Module.register("newsfeed", {
 				}
 			}
 		}
-		newsItems.sort(function (a, b) {
+		newsItems.sort((a, b) => {
 			const dateA = new Date(a.pubdate);
 			const dateB = new Date(b.pubdate);
 			return dateB - dateA;

--- a/defaultmodules/weather/weather.js
+++ b/defaultmodules/weather/weather.js
@@ -329,14 +329,14 @@ Module.register("weather", {
 	addFilters () {
 		this.nunjucksEnvironment().addFilter(
 			"formatTime",
-			function (date) {
+			(date) => {
 				return formatTime(this.config, date);
-			}.bind(this)
+			}
 		);
 
 		this.nunjucksEnvironment().addFilter(
 			"unit",
-			function (value, type, valueUnit) {
+			(value, type, valueUnit) => {
 				let formattedValue;
 				if (type === "temperature") {
 					if (value === null || value === undefined) {
@@ -365,40 +365,40 @@ Module.register("weather", {
 					formattedValue = WeatherUtils.convertWind(value, this.config.windUnits);
 				}
 				return formattedValue;
-			}.bind(this)
+			}
 		);
 
 		this.nunjucksEnvironment().addFilter(
 			"roundValue",
-			function (value) {
+			(value) => {
 				return this.roundValue(value);
-			}.bind(this)
+			}
 		);
 
 		this.nunjucksEnvironment().addFilter(
 			"decimalSymbol",
-			function (value) {
+			(value) => {
 				return value.toString().replace(/\./g, this.config.decimalSymbol);
-			}.bind(this)
+			}
 		);
 
 		this.nunjucksEnvironment().addFilter(
 			"calcNumSteps",
-			function (forecast) {
+			(forecast) => {
 				return Math.min(forecast.length, this.config.maxNumberOfDays);
-			}.bind(this)
+			}
 		);
 
 		this.nunjucksEnvironment().addFilter(
 			"calcNumEntries",
-			function (dataArray) {
+			(dataArray) => {
 				return Math.min(dataArray.length, this.config.maxEntries);
-			}.bind(this)
+			}
 		);
 
 		this.nunjucksEnvironment().addFilter(
 			"opacity",
-			function (currentStep, numSteps) {
+			(currentStep, numSteps) => {
 				if (this.config.fade && this.config.fadePoint < 1) {
 					if (this.config.fadePoint < 0) {
 						this.config.fadePoint = 0;
@@ -413,7 +413,7 @@ Module.register("weather", {
 				} else {
 					return 1;
 				}
-			}.bind(this)
+			}
 		);
 	}
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -82,6 +82,7 @@ export default defineConfig([
 			"no-unneeded-ternary": "error",
 			"no-useless-return": "error",
 			"object-shorthand": ["error", "methods"],
+			"prefer-arrow-callback": "error",
 			"prefer-const": "error",
 			"prefer-template": "error",
 			"require-await": "error"

--- a/js/app.js
+++ b/js/app.js
@@ -44,7 +44,7 @@ if (process.env.MM_CONFIG_FILE) {
 
 // The next part is here to prevent a major exception when there
 // is no internet connection. This could probable be solved better.
-process.on("uncaughtException", function (err) {
+process.on("uncaughtException", (err) => {
 	// ignore strange exceptions under aarch64 coming from systeminformation:
 	if (!err.stack.includes("node_modules/systeminformation")) {
 		Log.error("Whoops! There was an uncaught exception...");

--- a/js/electron.js
+++ b/js/electron.js
@@ -122,7 +122,7 @@ function createWindow () {
 	});
 
 	// Set responders for window events.
-	mainWindow.on("closed", function () {
+	mainWindow.on("closed", () => {
 		mainWindow = null;
 	});
 
@@ -146,7 +146,7 @@ function createWindow () {
 }
 
 // Quit when all windows are closed.
-app.on("window-all-closed", function () {
+app.on("window-all-closed", () => {
 	if (process.env.mmTestMode) {
 		// if we are running tests
 		app.quit();
@@ -155,7 +155,7 @@ app.on("window-all-closed", function () {
 	}
 });
 
-app.on("activate", function () {
+app.on("activate", () => {
 
 	/*
 	 * On OS X it's common to re-create a window in the app when the

--- a/js/loader.js
+++ b/js/loader.js
@@ -92,7 +92,7 @@ async function getModuleData () {
 	const moduleFiles = [];
 	const envVars = await getEnvVars();
 
-	modules.forEach(function (moduleData, index) {
+	modules.forEach((moduleData, index) => {
 		const module = moduleData.module;
 
 		const elements = module.split("/");

--- a/js/main.js
+++ b/js/main.js
@@ -14,7 +14,7 @@ let modules = [];
 async function createDomObjects () {
 	const domCreationPromises = [];
 
-	modules.forEach(function (module) {
+	modules.forEach((module) => {
 		if (typeof module.data.position !== "string") {
 			return;
 		}
@@ -279,7 +279,7 @@ function _hideModule (module, speed, callback, options = {}) {
 			Log.debug(`${module.identifier} Has animateOut: ${haveAnimateName}`);
 			module.hasAnimateOut = haveAnimateName;
 			addAnimateCSS(module.identifier, haveAnimateName, speed / 1000);
-			module.showHideTimer = setTimeout(function () {
+			module.showHideTimer = setTimeout(() => {
 				removeAnimateCSS(module.identifier, haveAnimateName);
 				Log.debug(`${module.identifier} Remove animateOut: ${module.hasAnimateOut}`);
 				// AnimateCSS is now done
@@ -298,7 +298,7 @@ function _hideModule (module, speed, callback, options = {}) {
 			moduleWrapper.style.transition = `opacity ${speed / 1000}s`;
 			moduleWrapper.style.opacity = 0;
 			moduleWrapper.classList.add("hidden");
-			module.showHideTimer = setTimeout(function () {
+			module.showHideTimer = setTimeout(() => {
 				// To not take up any space, we just make the position absolute.
 				// since it's fade out anyway, we can see it lay above or
 				// below other modules. This works way better than adjusting
@@ -394,7 +394,7 @@ function _showModule (module, speed, callback, options = {}) {
 			Log.debug(`${module.identifier} Has animateIn: ${haveAnimateName}`);
 			module.hasAnimateIn = haveAnimateName;
 			addAnimateCSS(module.identifier, haveAnimateName, speed / 1000);
-			module.showHideTimer = setTimeout(function () {
+			module.showHideTimer = setTimeout(() => {
 				removeAnimateCSS(module.identifier, haveAnimateName);
 				Log.debug(`${module.identifier} Remove animateIn: ${haveAnimateName}`);
 				module.hasAnimateIn = false;
@@ -404,7 +404,7 @@ function _showModule (module, speed, callback, options = {}) {
 			}, speed);
 		} else {
 			// default MM² Animate
-			module.showHideTimer = setTimeout(function () {
+			module.showHideTimer = setTimeout(() => {
 				if (typeof callback === "function") {
 					callback();
 				}
@@ -430,12 +430,12 @@ function _showModule (module, speed, callback, options = {}) {
  * update notification is not visible.
  */
 function updateWrapperStates () {
-	modulePositions.forEach(function (position) {
+	modulePositions.forEach((position) => {
 		const wrapper = selectWrapper(position);
 		const moduleWrappers = wrapper.getElementsByClassName("module");
 
 		let showWrapper = false;
-		Array.prototype.forEach.call(moduleWrappers, function (moduleWrapper) {
+		Array.prototype.forEach.call(moduleWrappers, (moduleWrapper) => {
 			if (moduleWrapper.style.position === "" || moduleWrapper.style.position === "static") {
 				showWrapper = true;
 			}
@@ -510,7 +510,7 @@ function setSelectionMethodsForModules (modules) {
 			searchClasses = className.split(" ");
 		}
 
-		const newModules = modules.filter(function (module) {
+		const newModules = modules.filter((module) => {
 			const classes = module.data.classes.toLowerCase().split(" ");
 
 			for (const searchClass of searchClasses) {
@@ -532,7 +532,7 @@ function setSelectionMethodsForModules (modules) {
 	 * @returns {Module[]} Filtered collection of modules.
 	 */
 	function exceptModule (module) {
-		const newModules = modules.filter(function (mod) {
+		const newModules = modules.filter((mod) => {
 			return mod.identifier !== module.identifier;
 		});
 
@@ -545,7 +545,7 @@ function setSelectionMethodsForModules (modules) {
 	 * @param {module} callback The function to execute with the module as an argument.
 	 */
 	function enumerate (callback) {
-		modules.map(function (module) {
+		modules.map((module) => {
 			callback(module);
 		});
 	}

--- a/js/module.js
+++ b/js/module.js
@@ -89,7 +89,7 @@ export class Module {
 			// Check to see if we need to render a template string or a file.
 			if ((/^.*((\.html)|(\.njk))$/).test(template)) {
 				// the template is a filename
-				this.nunjucksEnvironment().render(template, templateData, function (err, res) {
+				this.nunjucksEnvironment().render(template, templateData, (err, res) => {
 					if (err) {
 						Log.error(err);
 					}

--- a/js/releasenotes.js
+++ b/js/releasenotes.js
@@ -144,7 +144,7 @@ const createReleaseNotes = async () => {
 	// function to remove duplicates
 	const sortedArr = (arr) => {
 		return arr.filter((item,
-			index) => (arr.indexOf(item) === index && item !== "@dependabot[bot]")).sort(function (a, b) {
+			index) => (arr.indexOf(item) === index && item !== "@dependabot[bot]")).sort((a, b) => {
 			return a.toLowerCase().localeCompare(b.toLowerCase());
 		});
 	};

--- a/js/translator.js
+++ b/js/translator.js
@@ -55,7 +55,7 @@ export const Translator = (function () {
 				if (variables.fallback && !template.match(new RegExp("{.+}"))) {
 					templateToUse = variables.fallback;
 				}
-				return templateToUse.replace(new RegExp("{([^}]+)}", "g"), function (_unused, varName) {
+				return templateToUse.replace(new RegExp("{([^}]+)}", "g"), (_unused, varName) => {
 					return varName in variables ? variables[varName] : `{${varName}}`;
 				});
 			}


### PR DESCRIPTION
In #4240 we discussed function declarations vs. arrow functions, and the consensus was to lean towards arrow functions.

This is a follow-up to that: I enabled the ESLint rule `prefer-arrow-callback`. All found issues in the affected files were fixed automatically by ESLint itself, no manual changes needed.

**Outcome:** This makes the code more consistent.